### PR TITLE
feat(mcps): add figma-context-mcp to shared MCP servers

### DIFF
--- a/inventory/default/group_vars/all/agent_mcps/servers.yml
+++ b/inventory/default/group_vars/all/agent_mcps/servers.yml
@@ -54,13 +54,13 @@ agent_mcps:
   # Figma 设计稿读取（第三方 figma-context-mcp，无官方额度限制）
   # 需要在 secrets.yml 中配置 secrets.api_keys.figma 为你的 Figma Personal Access Token
   # 获取方式: Figma → Settings → Account → Personal access tokens → Generate new token
-  figma-context-mcp:
-    type: "stdio"
-    command: "npx"
-    args: ["-y", "figma-developer-mcp", "--stdio"]
-    env:
-      FIGMA_API_KEY: "{{ (secrets | default({})).get('api_keys', {}).get('figma', '') }}"
-    startup_timeout_sec: 30
+  # figma-context-mcp:
+  #  type: "stdio"
+  #  command: "npx"
+  #  args: ["-y", "figma-developer-mcp", "--stdio"]
+  #  env:
+  #    FIGMA_API_KEY: "{{ (secrets | default({})).get('api_keys', {}).get('figma', '') }}"
+  #  startup_timeout_sec: 30
 
   # Serena 代码分析和重构
   serena:

--- a/inventory/default/group_vars/all/agent_mcps/servers.yml
+++ b/inventory/default/group_vars/all/agent_mcps/servers.yml
@@ -51,6 +51,17 @@ agent_mcps:
       DEFAULT_SEARCH_ENGINE: "duckduckgo"
       ALLOWED_SEARCH_ENGINES: "duckduckgo,bing,brave"
 
+  # Figma 设计稿读取（第三方 figma-context-mcp，无官方额度限制）
+  # 需要在 secrets.yml 中配置 secrets.api_keys.figma 为你的 Figma Personal Access Token
+  # 获取方式: Figma → Settings → Account → Personal access tokens → Generate new token
+  figma-context-mcp:
+    type: "stdio"
+    command: "npx"
+    args: ["-y", "figma-developer-mcp", "--stdio"]
+    env:
+      FIGMA_API_KEY: "{{ (secrets | default({})).get('api_keys', {}).get('figma', '') }}"
+    startup_timeout_sec: 30
+
   # Serena 代码分析和重构
   serena:
     type: "stdio"

--- a/playbooks/setup_codex.yml
+++ b/playbooks/setup_codex.yml
@@ -96,15 +96,31 @@
     - name: 归一化共享 Codex MCP 配置
       set_fact:
         codex_mcp_servers_effective: >-
+          {%- set _filtered_env = (
+                item.value.env | default({})
+                | dict2items
+                | rejectattr('value', 'equalto', '')
+                | items2dict
+              ) if (item.value.env is defined and item.value.env is mapping)
+              else {}
+          -%}
           {{
             codex_mcp_servers_effective
             | combine(
                 {
                   item.key: (
-                    item.value
-                    | dict2items
-                    | rejectattr('key', 'equalto', 'type')
-                    | items2dict
+                    (
+                      item.value
+                      | dict2items
+                      | rejectattr('key', 'equalto', 'type')
+                      | rejectattr('key', 'equalto', 'env')
+                      | rejectattr('value', 'equalto', {})
+                      | items2dict
+                    )
+                    | combine(
+                        (_filtered_env | length > 0)
+                        | ternary({'env': _filtered_env}, {})
+                      )
                   )
                 },
                 recursive=True


### PR DESCRIPTION
## Summary

- Add `figma-context-mcp` to the shared `agent_mcps` in `servers.yml`, making Figma design data available to all agents (Claude Code / Codex / Gemini CLI / Copilot CLI / Cursor)
- Uses the third-party [`figma-developer-mcp`](https://github.com/GLips/Figma-Context-MCP) package (Framelink), which has no official rate limits unlike Figma's remote MCP (6 calls/month on free plan)
- Runs in stdio mode via `npx -y figma-developer-mcp --stdio`
- `FIGMA_API_KEY` is read from `secrets.api_keys.figma`, consistent with existing API key patterns
- `startup_timeout_sec: 30` to handle first-run npx download delay

## Usage

Users need to add their Figma Personal Access Token in `secrets.yml`:

```yaml
secrets:
  api_keys:
    figma: "fig_xxx"
```

Token can be generated at: Figma → Settings → Account → Personal access tokens → Generate new token

## Test plan

- [ ] Run `uv run ansible-playbook playbooks/setup_claude_code.yml` and verify `figma-context-mcp` appears in the generated config
- [ ] Run `uv run ansible-playbook playbooks/setup_codex.yml` and verify the MCP entry is present in `config.toml`
- [ ] Verify the MCP server starts successfully in a Claude Code / Codex session with a valid Figma token