### PR TITLE
feat(agent_claude_code): support effortLevel setting for Opus 4.7+

### DIFF
--- a/roles/agent_claude_code/README.md
+++ b/roles/agent_claude_code/README.md
@@ -57,7 +57,8 @@ agent_claude_code_settings:
     ANTHROPIC_API_KEY: xxx
     ANTHROPIC_BASE_URL: https://example.com
   model: claude-sonnet-4-5
-  alwaysThinkingEnabled: true
+  alwaysThinkingEnabled: false
+  effortLevel: xhigh
   outputStyle: engineer-professional
   language: zh-CN
   permissions:
@@ -109,7 +110,8 @@ agent_claude_code_result:
             ANTHROPIC_API_KEY: "{{ vault_anthropic_api_key }}"
             ANTHROPIC_BASE_URL: https://example.com
           model: claude-sonnet-4-5
-          alwaysThinkingEnabled: true
+          alwaysThinkingEnabled: false
+          effortLevel: xhigh
           outputStyle: engineer-professional
           language: zh-CN
           permissions:
@@ -142,6 +144,7 @@ agent_claude_code_result:
 - `output-styles` 必须通过外部路径传入，本 role 不再内置这些目录内容。
 - `skills` 不再由本 role 直接同步，建议改用 `managed_agent_skills` role 统一管理。
 - 本 role 不管理 `agents` 目录，也不会主动创建它。
+- Claude Opus 4.7+ 建议使用 `alwaysThinkingEnabled: false` 配合 `effortLevel`，避免触发已废弃的 `thinking.enabled` 请求语义。
 - `agent_claude_code_plugins_to_install` 为空时，会自动使用 `agent_claude_code_settings.enabledPlugins` 作为插件安装目标。
 - `agent_claude_code_output_styles_src` 会自动归一化为以 `/` 结尾的目录同步语义。
 - `agent_claude_code_confirm_settings_update` 和 `agent_claude_code_confirm_user_json_update` 适用于手动执行 playbook 的交互确认；如果是无人值守执行，应保持为 `false`。

--- a/roles/agent_claude_code/defaults/main.yml
+++ b/roles/agent_claude_code/defaults/main.yml
@@ -84,6 +84,7 @@ agent_claude_code_settings:
   env: {}
   model: ""
   alwaysThinkingEnabled: false
+  effortLevel: ""
   outputStyle: ""
   language: ""
   permissions:

--- a/roles/agent_claude_code/molecule/default/converge.yml
+++ b/roles/agent_claude_code/molecule/default/converge.yml
@@ -92,7 +92,8 @@
             ANTHROPIC_API_KEY: test-key
             ANTHROPIC_BASE_URL: https://example.test
           model: claude-sonnet-4-5
-          alwaysThinkingEnabled: true
+          alwaysThinkingEnabled: false
+          effortLevel: high
           outputStyle: custom-style
           language: zh-CN
           permissions:

--- a/roles/agent_claude_code/molecule/default/files/settings.schema.json
+++ b/roles/agent_claude_code/molecule/default/files/settings.schema.json
@@ -28,6 +28,9 @@
     "alwaysThinkingEnabled": {
       "type": "boolean"
     },
+    "effortLevel": {
+      "type": "string"
+    },
     "outputStyle": {
       "type": "string"
     },

--- a/roles/agent_claude_code/molecule/default/verify.yml
+++ b/roles/agent_claude_code/molecule/default/verify.yml
@@ -23,7 +23,8 @@
             ANTHROPIC_API_KEY: test-key
             ANTHROPIC_BASE_URL: https://example.test
           model: claude-sonnet-4-5
-          alwaysThinkingEnabled: true
+          alwaysThinkingEnabled: false
+          effortLevel: high
           outputStyle: custom-style
           language: zh-CN
           permissions:
@@ -102,6 +103,8 @@
           - not (agent_claude_code_result.changed | bool)
           - (agent_claude_code_settings_json_final.content | b64decode | from_json).outputStyle == 'custom-style'
           - (agent_claude_code_settings_json_final.content | b64decode | from_json).env.ANTHROPIC_API_KEY == 'test-key'
+          - (agent_claude_code_settings_json_final.content | b64decode | from_json).alwaysThinkingEnabled == false
+          - (agent_claude_code_settings_json_final.content | b64decode | from_json).effortLevel == 'high'
           - (agent_claude_code_user_json_final.content | b64decode | from_json).untouched == true
           - (agent_claude_code_user_json_final.content | b64decode | from_json).mcpServers['local-demo'].command == 'node'
           - (agent_claude_code_user_json_final.content | b64decode | from_json).mcpServers.existing.command == 'python3'

--- a/roles/agent_claude_code/tasks/validate.yml
+++ b/roles/agent_claude_code/tasks/validate.yml
@@ -29,6 +29,7 @@
           'env': {},
           'model': '',
           'alwaysThinkingEnabled': false,
+          'effortLevel': '',
           'outputStyle': '',
           'language': '',
           'permissions': {
@@ -60,6 +61,7 @@
     that:
       - agent_claude_code_settings_normalized.env is mapping
       - agent_claude_code_settings_normalized.model | length > 0
+      - agent_claude_code_settings_normalized.effortLevel is string
       - agent_claude_code_settings_normalized.outputStyle | length > 0
       - agent_claude_code_settings_normalized.permissions is mapping
       - agent_claude_code_settings_normalized.permissions.allow is sequence

--- a/roles/agent_claude_code/tasks/verify.yml
+++ b/roles/agent_claude_code/tasks/verify.yml
@@ -55,6 +55,16 @@
     - agent_claude_code_manage_settings | bool
     - agent_claude_code_settings_normalized.language | length > 0
 
+- name: 验证 settings.json effortLevel 字段
+  assert:
+    that:
+      - agent_claude_code_settings_data.effortLevel == agent_claude_code_settings_normalized.effortLevel
+    fail_msg: "settings.json effortLevel 字段不匹配"
+    success_msg: "✓ settings.json effortLevel 字段正确"
+  when:
+    - agent_claude_code_manage_settings | bool
+    - agent_claude_code_settings_normalized.effortLevel | length > 0
+
 - name: 验证 settings.json 启用插件配置
   assert:
     that:

--- a/roles/agent_claude_code/templates/settings.json.j2
+++ b/roles/agent_claude_code/templates/settings.json.j2
@@ -15,6 +15,9 @@
   'cleanupPeriodDays': agent_claude_code_settings_normalized.cleanupPeriodDays,
   'hooks': agent_claude_code_settings_normalized.hooks
 } %}
+{% if agent_claude_code_settings_normalized.effortLevel is defined and agent_claude_code_settings_normalized.effortLevel | length > 0 %}
+{% set settings_data = settings_data | combine({'effortLevel': agent_claude_code_settings_normalized.effortLevel}, recursive=True) %}
+{% endif %}
 {% if agent_claude_code_settings_normalized.permissions.defaultMode is defined and agent_claude_code_settings_normalized.permissions.defaultMode != 'default' %}
 {% set settings_data = settings_data | combine({'permissions': {'defaultMode': agent_claude_code_settings_normalized.permissions.defaultMode}}, recursive=True) %}
 {% endif %}


### PR DESCRIPTION
## Summary

Add support for the `effortLevel` field in `agent_claude_code` settings. Claude Opus 4.7+ deprecates the old `thinking.enabled` request semantics and recommends controlling reasoning strength via `effortLevel` combined with `alwaysThinkingEnabled: false`.

The field is emitted into `~/.claude/settings.json` only when explicitly configured, so existing inventories are unaffected.

## Changes

- `defaults/main.yml`: add `effortLevel: ""` default.
- `tasks/validate.yml`: include `effortLevel` in the normalized settings schema and assert it is a string.
- `templates/settings.json.j2`: conditionally render `effortLevel` when non-empty (keeps output backward compatible).
- `tasks/verify.yml`: assert the rendered `settings.json` matches the configured `effortLevel`.
- `molecule/default`: exercise the new field in `converge.yml`, `verify.yml`, and `files/settings.schema.json`.
- `README.md`: document the Opus 4.7+ recommendation and update example snippets.

## Test plan

- [x] `cd roles/agent_claude_code && uv run molecule test`
- [ ] (Reviewer) Spot-check generated `~/.claude/settings.json` on a host configured with `effortLevel: xhigh`.