### PR TITLE
chore(default): 从 zzq profile 合并通用配置改进

### DIFF
--- a/inventory/default/group_vars/all/agent_mcps/servers.yml
+++ b/inventory/default/group_vars/all/agent_mcps/servers.yml
@@ -39,7 +39,7 @@ agent_mcps:
   playwright:
     type: "stdio"
     command: "npx"
-    args: ["@playwright/mcp@latest"]
+    args: ["-y", "@playwright/mcp@latest"]
 
   # 联网搜索
   open-websearch:
@@ -50,6 +50,26 @@ agent_mcps:
       MODE: "stdio"
       DEFAULT_SEARCH_ENGINE: "duckduckgo"
       ALLOWED_SEARCH_ENGINES: "duckduckgo,bing,brave"
+
+  # 联网搜索（火山引擎 AskEcho）
+  mcp-server-askecho-search-infinity:
+    type: "stdio"
+    command: uvx
+    args:
+      - "--from"
+      - "git+https://github.com/volcengine/mcp-server@9f2f824f1bdfe7b9d0e33ec1bdf666e4814fbad5#subdirectory=server/mcp_server_askecho_search_infinity"
+      - "mcp-server-askecho-search-infinity"
+    env:
+      ASK_ECHO_SEARCH_INFINITY_API_KEY: "{{ (secrets | default({})).get('mcp_server_askecho_search_infinity_api_key', '') }}"
+
+  # Codecov 代码覆盖率统计
+  codecov:
+    type: "stdio"
+    command: "npx"
+    args: ["-y", "@egulatee/mcp-codecov"]
+    env:
+      CODECOV_BASE_URL: https://codecov.io
+      CODECOV_TOKEN: "{{ (secrets | default({})).get('codecov_token', '') }}"
 
   # Figma 设计稿读取（第三方 figma-context-mcp，无官方额度限制）
   # 需要在 secrets.yml 中配置 secrets.api_keys.figma 为你的 Figma Personal Access Token

--- a/inventory/default/group_vars/all/agent_mcps/servers.yml
+++ b/inventory/default/group_vars/all/agent_mcps/servers.yml
@@ -51,25 +51,25 @@ agent_mcps:
       DEFAULT_SEARCH_ENGINE: "duckduckgo"
       ALLOWED_SEARCH_ENGINES: "duckduckgo,bing,brave"
 
-  # 联网搜索（火山引擎 AskEcho）
-  mcp-server-askecho-search-infinity:
-    type: "stdio"
-    command: uvx
-    args:
-      - "--from"
-      - "git+https://github.com/volcengine/mcp-server@9f2f824f1bdfe7b9d0e33ec1bdf666e4814fbad5#subdirectory=server/mcp_server_askecho_search_infinity"
-      - "mcp-server-askecho-search-infinity"
-    env:
-      ASK_ECHO_SEARCH_INFINITY_API_KEY: "{{ (secrets | default({})).get('mcp_server_askecho_search_infinity_api_key', '') }}"
+  # 联网搜索（火山引擎 AskEcho），需要配置 secrets.mcp_server_askecho_search_infinity_api_key
+  # mcp-server-askecho-search-infinity:
+  #   type: "stdio"
+  #   command: uvx
+  #   args:
+  #     - "--from"
+  #     - "git+https://github.com/volcengine/mcp-server@9f2f824f1bdfe7b9d0e33ec1bdf666e4814fbad5#subdirectory=server/mcp_server_askecho_search_infinity"
+  #     - "mcp-server-askecho-search-infinity"
+  #   env:
+  #     ASK_ECHO_SEARCH_INFINITY_API_KEY: "{{ (secrets | default({})).get('mcp_server_askecho_search_infinity_api_key', '') }}"
 
-  # Codecov 代码覆盖率统计
-  codecov:
-    type: "stdio"
-    command: "npx"
-    args: ["-y", "@egulatee/mcp-codecov"]
-    env:
-      CODECOV_BASE_URL: https://codecov.io
-      CODECOV_TOKEN: "{{ (secrets | default({})).get('codecov_token', '') }}"
+  # Codecov 代码覆盖率统计，需要配置 secrets.codecov_token
+  # codecov:
+  #   type: "stdio"
+  #   command: "npx"
+  #   args: ["-y", "@egulatee/mcp-codecov"]
+  #   env:
+  #     CODECOV_BASE_URL: https://codecov.io
+  #     CODECOV_TOKEN: "{{ (secrets | default({})).get('codecov_token', '') }}"
 
   # Figma 设计稿读取（第三方 figma-context-mcp，无官方额度限制）
   # 需要在 secrets.yml 中配置 secrets.api_keys.figma 为你的 Figma Personal Access Token

--- a/inventory/default/group_vars/all/agent_skills/items.yml
+++ b/inventory/default/group_vars/all/agent_skills/items.yml
@@ -17,6 +17,7 @@ agent_skills_items:
       - claude-code
       - codex
       - github-copilot
+      - cursor
     scope: global
 
   - name: 安装 obra/superpowers 相关 Skills
@@ -41,6 +42,7 @@ agent_skills_items:
       - claude-code
       - codex
       - github-copilot
+      - cursor
     scope: global
 
   - name: 安装 vercel-labs/skills 官方相关 Skills
@@ -52,6 +54,7 @@ agent_skills_items:
       - claude-code
       - codex
       - github-copilot
+      - cursor
     scope: global
 
   - name: 安装 github/awesome-copilot 官方相关 Skills
@@ -63,6 +66,7 @@ agent_skills_items:
       - claude-code
       - codex
       - github-copilot
+      - cursor
     scope: global
 
   - name: 安装 jkeskikangas/skills 的 AGENTS.md 管理技能
@@ -77,6 +81,18 @@ agent_skills_items:
       - github-copilot
       - cursor
       - opencode
+    scope: global
+
+  - name: 安装 upstash/context7 Skills
+    state: present
+    source: upstash/context7
+    skills:
+      - context7-cli # Context7 API 文档检索
+    agents:
+      - claude-code
+      - codex
+      - github-copilot
+      - cursor
     scope: global
 #
 #   - name: 卸载 Claude 遗留 skill

--- a/inventory/default/group_vars/all/claude_code/models.yml
+++ b/inventory/default/group_vars/all/claude_code/models.yml
@@ -1,6 +1,8 @@
 private_variables: # 仅供当前文件复用的变量
   volces_api_base_url: "https://ark.cn-beijing.volces.com/api/coding"
   qiniu_api_base_url: "https://api.qnaigc.com"
+  openrouter_api_base_url: "https://openrouter.ai/api"
+  deepseek_api_base_url: "https://api.deepseek.com/anthropic"
 
 claude_code_model_configs: # 模型配置
   # 模型配置示例，实际使用时请根据需要修改或删除
@@ -12,6 +14,10 @@ claude_code_model_configs: # 模型配置
     base_url: "{{ private_variables.volces_api_base_url }}"
     api_key: "{{ (secrets | default({})).get('api_keys', {}).get('volces', '') }}"
     model: "kimi-k2.5"
+  volces_ark_code_latest: # Coding Plan 订阅模型，自动选择
+    base_url: "{{ private_variables.volces_api_base_url }}"
+    api_key: "{{ (secrets | default({})).get('api_keys', {}).get('volces', '') }}"
+    model: "ark-code-latest"
   qiniu_longcat_flash_lite: # 这个免费模型贼难用，不推荐
     base_url: "{{ private_variables.qiniu_api_base_url }}"
     api_key: "{{ (secrets | default({})).get('api_keys', {}).get('qiniu', '') }}"
@@ -24,5 +30,24 @@ claude_code_model_configs: # 模型配置
   anthropic_subscription: # Anthropic 官方订阅账户（Pro/Max/Team），无需 API Key
     auth: subscription
     model: "opus" # 内置别名：opus / sonnet / haiku / opusplan / opus[1m] / sonnet[1m]
+
+  # OpenRouter 示例
+  openrouter_claude_opus_4_6:
+    base_url: "{{ private_variables.openrouter_api_base_url }}"
+    api_key: "{{ (secrets | default({})).get('api_keys', {}).get('openrouter', '') }}"
+    model: "anthropic/claude-opus-4.6"
+  openrouter_free:
+    base_url: "{{ private_variables.openrouter_api_base_url }}"
+    api_key: "{{ (secrets | default({})).get('api_keys', {}).get('zzq_openrouter', '') }}"
+    model: "nvidia/nemotron-3-super-120b-a12b:free"
+
+  # DeepSeek Anthropic API 兼容示例（支持多模型别名）
+  deepseek_v4:
+    base_url: "{{ private_variables.deepseek_api_base_url }}"
+    api_key: "{{ (secrets | default({})).get('api_keys', {}).get('deepseek', '') }}"
+    opus_model: "deepseek-v4-pro[1m]"
+    sonnet_model: "deepseek-v4-pro[1m]"
+    haiku_model: "deepseek-v4-flash"
+    claude_code_subagent: "deepseek-v4-flash"
 
 claude_code_use_model: "qiniu_step_3_5_flash"

--- a/inventory/default/group_vars/all/claude_code/models.yml
+++ b/inventory/default/group_vars/all/claude_code/models.yml
@@ -49,5 +49,6 @@ claude_code_model_configs: # 模型配置
     sonnet_model: "deepseek-v4-pro[1m]"
     haiku_model: "deepseek-v4-flash"
     claude_code_subagent: "deepseek-v4-flash"
+    effort: "max"
 
 claude_code_use_model: "qiniu_step_3_5_flash"

--- a/inventory/default/group_vars/all/claude_code/settings.yml
+++ b/inventory/default/group_vars/all/claude_code/settings.yml
@@ -19,6 +19,8 @@ claude_code_settings:
     ANTHROPIC_DEFAULT_SONNET_MODEL: "{{ model_configs[claude_code_use_model].sonnet_model | default(model_configs[claude_code_use_model].model) if (model_configs[claude_code_use_model].auth | default('')) != 'subscription' else '' }}"
     ANTHROPIC_DEFAULT_HAIKU_MODEL: "{{ model_configs[claude_code_use_model].haiku_model | default(model_configs[claude_code_use_model].model) if (model_configs[claude_code_use_model].auth | default('')) != 'subscription' else '' }}"
     CLAUDE_CODE_SUBAGENT_MODEL: "{{ model_configs[claude_code_use_model].claude_code_subagent | default(model_configs[claude_code_use_model].model) if (model_configs[claude_code_use_model].auth | default('')) != 'subscription' else '' }}"
+    # 推理力度（仅部分 API 支持），可选值：minimal / low / medium / high / max
+    CLAUDE_CODE_EFFORT_LEVEL: "max"
     # 隐私与遥测控制
     DISABLE_TELEMETRY: "1"
     DISABLE_ERROR_REPORTING: "1"

--- a/inventory/default/group_vars/all/claude_code/settings.yml
+++ b/inventory/default/group_vars/all/claude_code/settings.yml
@@ -20,7 +20,7 @@ claude_code_settings:
     ANTHROPIC_DEFAULT_HAIKU_MODEL: "{{ model_configs[claude_code_use_model].haiku_model | default(model_configs[claude_code_use_model].model) if (model_configs[claude_code_use_model].auth | default('')) != 'subscription' else '' }}"
     CLAUDE_CODE_SUBAGENT_MODEL: "{{ model_configs[claude_code_use_model].claude_code_subagent | default(model_configs[claude_code_use_model].model) if (model_configs[claude_code_use_model].auth | default('')) != 'subscription' else '' }}"
     # 推理力度（仅部分 API 支持），可选值：minimal / low / medium / high / max
-    CLAUDE_CODE_EFFORT_LEVEL: "max"
+    CLAUDE_CODE_EFFORT_LEVEL: "{{ model_configs[claude_code_use_model].effort | default('max') }}"
     # 隐私与遥测控制
     DISABLE_TELEMETRY: "1"
     DISABLE_ERROR_REPORTING: "1"

--- a/inventory/default/group_vars/all/opencommit/settings.yml
+++ b/inventory/default/group_vars/all/opencommit/settings.yml
@@ -6,4 +6,4 @@
 opencommit_settings:
   OCO_EMOJI: true
   OCO_DESCRIPTION: false
-  OCO_LANGUAGE: zh-CN
+  OCO_LANGUAGE: zh_CN


### PR DESCRIPTION
## 概述

从 `private-config` 分支的 `inventory/zzq/` profile 中提取通用改进，合并到 `inventory/default/`。

## 改动详情

### Bug 修复
- **playwright MCP**：args 添加 `-y` 标志，修复非交互环境下 npx 卡在确认提示的问题
- **OpenCommit 语言格式**：`OCO_LANGUAGE` 从 `zh-CN` 修正为 `zh_CN`（OpenCommit 使用下划线格式）

### 通用功能增强
- **新增 MCP 服务**：`mcp-server-askecho-search-infinity`（火山引擎联网搜索）和 `codecov`（代码覆盖率统计）
- **Agent Skills**：所有条目的 `agents` 列表增加 `cursor`，新增 `upstash/context7` Skills 条目
- **模型示例扩充**：新增 `volces_ark_code_latest`、OpenRouter 系列、DeepSeek V4 模型示例（含多模型别名演示）
- **Claude Code 设置**：新增 `CLAUDE_CODE_EFFORT_LEVEL` 配置项

## 合并原则

仅合并通用配置改进，以下 zzq 个人偏好**不合并**：
- 模型/API provider 的默认选择保持原样
- subscription 兼容逻辑保持不变
- 个人插件（如 gopls-lsp）不纳入 default
- 个人 OpenCommit 偏好（EMOJI/ONE_LINE_COMMIT/GITPUSH）不纳入