### PR TITLE
feat: migrate generic tool integrations to skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,6 +200,7 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+.playwright-cli
 
 # Marimo
 marimo/_static/

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -3,29 +3,36 @@ project_name: "agent-config-ansible"
 
 
 # list of languages for which language servers are started; choose from:
-#   al                  bash                clojure             cpp                 csharp
+#   al                  angular             ansible             bash                c
+#   clojure             cpp                 cpp_ccls            crystal             csharp
 #   csharp_omnisharp    dart                elixir              elm                 erlang
 #   fortran             fsharp              go                  groovy              haskell
-#   haxe                java                julia               kotlin              lua
-#   markdown
-#   matlab              nix                 pascal              perl                php
-#   php_phpactor        powershell          python              python_jedi         r
+#   haxe                hlsl                html                java                javascript
+#   json                julia               kotlin              lean4               lua
+#   luau                markdown            matlab              msl                 nix
+#   ocaml               pascal              perl                php                 php_phpactor
+#   powershell          python              python_jedi         python_ty           r
 #   rego                ruby                ruby_solargraph     rust                scala
-#   swift               terraform           toml                typescript          typescript_vts
-#   vue                 yaml                zig
-#   (This list may be outdated. For the current list, see values of Language enum here:
-#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
-#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+#   scss                solidity            swift               systemverilog       terraform
+#   toml                typescript          typescript_vts      vue                 yaml
+#   zig
+#   (This list is generated from Serena's Language enum; see:
+#   https://github.com/oraios/serena/blob/main/src/solid_lsp/ls_config.rs
+#   and the language server docs:
+#   https://oraios.github.io/serena/01-about/020_programming_languages.html#language-servers)
 # Note:
-#   - For C, use cpp
-#   - For JavaScript, use typescript
+#   - For C, use c or cpp
+#   - For JavaScript, use javascript or typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
 #   - For Free Pascal/Lazarus, use pascal
 # Special requirements:
 #   Some languages require additional setup/installations.
-#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
-# When using multiple languages, the first language server that supports a given file will be used for that file.
-# The first language is the default language and the respective language server will be used as a fallback.
-# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+#   See here for details:
+#   https://oraios.github.io/serena/01-about/020_programming_languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used.
+# The first language is the default language and its server is used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is ignored.
 languages:
 - bash
 
@@ -60,57 +67,20 @@ read_only: false
 
 # list of tool names to exclude.
 # This extends the existing exclusions (e.g. from the global configuration)
-#
-# Below is the complete list of tools for convenience.
-# To make sure you have the latest list of tools, and to view their descriptions, 
-# execute `uv run scripts/print_tool_overview.py`.
-#
-#  * `activate_project`: Activates a project based on the project name or path.
-#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
-#  * `create_text_file`: Creates/overwrites a file in the project directory.
-#  * `delete_memory`: Delete a memory file. Should only happen if a user asks for it explicitly,
-#       for example by saying that the information retrieved from a memory file is no longer correct
-#       or no longer relevant for the project.
-#  * `edit_memory`: Replaces content matching a regular expression in a memory.
-#  * `execute_shell_command`: Executes a shell command.
-#  * `find_file`: Finds files in the given relative paths
-#  * `find_referencing_symbols`: Finds symbols that reference the given symbol using the language server backend
-#  * `find_symbol`: Performs a global (or local) search using the language server backend.
-#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
-#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
-#  * `initial_instructions`: Provides instructions Serena usage (i.e. the 'Serena Instructions Manual')
-#       for clients that do not read the initial instructions when the MCP server is connected.
-#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
-#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
-#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
-#  * `list_memories`: List available memories. Any memory can be read using the `read_memory` tool.
-#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
-#  * `read_file`: Reads a file within the project directory.
-#  * `read_memory`: Read the content of a memory file. This tool should only be used if the information
-#       is relevant to the current task. You can infer whether the information
-#       is relevant from the memory file name.
-#       You should not read the same memory file multiple times in the same conversation.
-#  * `rename_memory`: Renames or moves a memory. Moving between project and global scope is supported
-#       (e.g., renaming "global/foo" to "bar" moves it from global to project scope).
-#  * `rename_symbol`: Renames a symbol throughout the codebase using language server refactoring capabilities.
-#       For JB, we use a separate tool.
-#  * `replace_content`: Replaces content in a file (optionally using regular expressions).
-#  * `replace_symbol_body`: Replaces the full definition of a symbol using the language server backend.
-#  * `safe_delete_symbol`:
-#  * `search_for_pattern`: Performs a search for a pattern in the project.
-#  * `write_memory`: Write some information (utf-8-encoded) about this project that can be useful for future tasks to a memory in md format.
-#       The memory name should be meaningful.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 excluded_tools: []
 
 # list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
 # This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 included_optional_tools: []
 
 # fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
 # This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 fixed_tools: []
 
-# list of mode names to that are always to be included in the set of active modes
+# list of mode names that are always included in the set of active modes
 # The full set of modes to be activated is base_modes + default_modes.
 # If the setting is undefined, the base_modes from the global configuration (serena_config.yml) apply.
 # Otherwise, this setting overrides the global configuration.
@@ -118,11 +88,14 @@ fixed_tools: []
 # Set this to a list of mode names to always include the respective modes for this project.
 base_modes:
 
-# list of mode names that are to be activated by default.
-# The full set of modes to be activated is base_modes + default_modes.
-# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
 # Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
 # This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 default_modes:
 
 # initial prompt for the project. It will always be given to the LLM upon activating the project
@@ -152,3 +125,19 @@ ignored_memory_patterns: []
 # Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
 # No documentation on options means no options are available.
 ls_specific_settings: {}
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes: []
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md

--- a/inventory/default/group_vars/all/agent_mcps/servers.yml
+++ b/inventory/default/group_vars/all/agent_mcps/servers.yml
@@ -18,28 +18,11 @@
 #   http:  url (+ headers / bearer_token_env_var 可选)
 
 agent_mcps:
-  # Context7 API 文档检索
-  context7:
-    type: "stdio"
-    command: "npx"
-    args: ["-y", "@upstash/context7-mcp"]
-
   # 用于自动获取网络内容，并转换成 Markdown 格式给 Agent
   mcp-server-fetch:
     type: "stdio"
     command: "uvx"
     args: ["mcp-server-fetch"]
-
-  # 用于自动联网搜索开源仓库信息
-  deepwiki:
-    type: "http"
-    url: "https://mcp.deepwiki.com/mcp"
-
-  # playwright 浏览器自动化
-  playwright:
-    type: "stdio"
-    command: "npx"
-    args: ["@playwright/mcp@latest"]
 
   # 联网搜索
   open-websearch:
@@ -50,6 +33,15 @@ agent_mcps:
       MODE: "stdio"
       DEFAULT_SEARCH_ENGINE: "duckduckgo"
       ALLOWED_SEARCH_ENGINES: "duckduckgo,bing,brave"
+
+  # codecov MCP 代码覆盖率统计
+  codecov:
+    type: "stdio"
+    command: "npx"
+    args: ["-y", "@egulatee/mcp-codecov"]
+    env:
+      CODECOV_BASE_URL: "https://codecov.io"
+      CODECOV_TOKEN: "{{ (secrets | default({})).get('codecov_token', '') }}"
 
   # Figma 设计稿读取（第三方 figma-context-mcp，无官方额度限制）
   # 需要在 secrets.yml 中配置 secrets.api_keys.figma 为你的 Figma Personal Access Token

--- a/inventory/default/group_vars/all/agent_skills/items.yml
+++ b/inventory/default/group_vars/all/agent_skills/items.yml
@@ -6,6 +6,12 @@
 # - GitHub shorthand / Git URL：适合 local 与 remote
 # - 本地路径：通常只适用于 ansible_connection=local，或目标机已存在相同路径
 
+agent_skills_default_agents:
+  - claude-code
+  - codex
+  - github-copilot
+  - cursor
+
 agent_skills_items:
   - name: 安装 anthropics/skills 官方相关 Skills
     state: present
@@ -13,10 +19,7 @@ agent_skills_items:
     skills:
       - frontend-design # 产出高质量、非模板化的前端界面
       - skill-creator # 创建、改进和评测 skill
-    agents:
-      - claude-code
-      - codex
-      - github-copilot
+    agents: "{{ agent_skills_default_agents }}"
     scope: global
 
   - name: 安装 obra/superpowers 相关 Skills
@@ -37,10 +40,7 @@ agent_skills_items:
       - verification-before-completion # 宣称完成前先执行必要验证
       - writing-plans # 编码前把多步骤任务整理成实施计划
       - writing-skills # 编写、修改和验证 skill 内容
-    agents:
-      - claude-code
-      - codex
-      - github-copilot
+    agents: "{{ agent_skills_default_agents }}"
     scope: global
 
   - name: 安装 vercel-labs/skills 官方相关 Skills
@@ -48,10 +48,7 @@ agent_skills_items:
     source: vercel-labs/skills
     skills:
       - find-skills # 通过 npx find-skills 命令行工具自动查找和安装技能
-    agents:
-      - claude-code
-      - codex
-      - github-copilot
+    agents: "{{ agent_skills_default_agents }}"
     scope: global
 
   - name: 安装 github/awesome-copilot 官方相关 Skills
@@ -59,10 +56,39 @@ agent_skills_items:
     source: github/awesome-copilot
     skills:
       - gh-cli # GitHub CLI 相关技能，提供与 GitHub 仓库、Issue、PR 等交互的能力
-    agents:
-      - claude-code
-      - codex
-      - github-copilot
+    agents: "{{ agent_skills_default_agents }}"
+    scope: global
+
+  - name: 安装 upstash/context7 Skills
+    state: present
+    source: upstash/context7
+    skills:
+      - context7-cli # Context7 API 文档检索
+    agents: "{{ agent_skills_default_agents }}"
+    scope: global
+
+  - name: 安装 davidkiss/smart-ai-skills 的 reflection Skill
+    state: present
+    source: davidkiss/smart-ai-skills
+    skills:
+      - reflection # 完成任务前进行自我反思与质量审查
+    agents: "{{ agent_skills_default_agents }}"
+    scope: global
+
+  - name: 安装 aahl/skills 的 deepwiki Skill
+    state: present
+    source: aahl/skills
+    skills:
+      - mcp-deepwiki # DeepWiki MCP 文档查询
+    agents: "{{ agent_skills_default_agents }}"
+    scope: global
+
+  - name: 安装 microsoft/playwright-cli 的 playwright Skill
+    state: present
+    source: microsoft/playwright-cli
+    skills:
+      - playwright-cli # Playwright 浏览器自动化
+    agents: "{{ agent_skills_default_agents }}"
     scope: global
 
   - name: 安装 jkeskikangas/skills 的 AGENTS.md 管理技能

--- a/inventory/default/group_vars/all/claude_code/models.yml
+++ b/inventory/default/group_vars/all/claude_code/models.yml
@@ -12,6 +12,10 @@ claude_code_model_configs: # 模型配置
     base_url: "{{ private_variables.volces_api_base_url }}"
     api_key: "{{ (secrets | default({})).get('api_keys', {}).get('volces', '') }}"
     model: "kimi-k2.5"
+  volces_ark_code_latest: # Coding Plan 订阅模型，自动选择
+    base_url: "{{ private_variables.volces_api_base_url }}"
+    api_key: "{{ (secrets | default({})).get('api_keys', {}).get('volces', '') }}"
+    model: "ark-code-latest"
   qiniu_longcat_flash_lite: # 这个免费模型贼难用，不推荐
     base_url: "{{ private_variables.qiniu_api_base_url }}"
     api_key: "{{ (secrets | default({})).get('api_keys', {}).get('qiniu', '') }}"

--- a/inventory/default/group_vars/all/claude_code/settings.yml
+++ b/inventory/default/group_vars/all/claude_code/settings.yml
@@ -56,7 +56,6 @@ claude_code_settings:
       - mcp__open-websearch__search
       - mcp__open-websearch__fetchLinuxDoArticle
       - mcp__open-websearch__fetchGithubReadme
-      - mcp__context7__resolve-library-id
       - mcp__serena__get_current_config
     deny: []
 

--- a/inventory/default/group_vars/all/codex/settings.yml
+++ b/inventory/default/group_vars/all/codex/settings.yml
@@ -9,6 +9,9 @@ codex_settings:
   # sandbox_mode: read-only / workspace-write / danger-full-access
   sandbox_mode: "read-only"
 
+  # approvals_reviewer: user / guardian_subagent
+  approvals_reviewer: "user"
+
   # approval_policy: untrusted / on-failure / on-request / never
   # approval_policy: "on-request"
 

--- a/inventory/default/group_vars/all/gemini_cli/mcp_servers.yml
+++ b/inventory/default/group_vars/all/gemini_cli/mcp_servers.yml
@@ -2,4 +2,12 @@
 # 默认共享 MCP 定义统一维护在 group_vars/all/agent_mcps/servers.yml 的 agent_mcps 下。
 # 这里仅放 Gemini 特有的覆盖项；会在渲染 ~/.gemini/settings.json 前与共享配置递归合并。
 
-gemini_mcp_servers: {}
+gemini_mcp_servers:
+  # 共享默认 MCP 已移除 context7 / deepwiki；Gemini 继续通过本文件保留这两个默认能力。
+  context7:
+    type: "stdio"
+    command: "npx"
+    args: ["-y", "@upstash/context7-mcp"]
+  deepwiki:
+    type: "http"
+    url: "https://mcp.deepwiki.com/mcp"

--- a/inventory/default/group_vars/all/gemini_cli/mcp_servers.yml
+++ b/inventory/default/group_vars/all/gemini_cli/mcp_servers.yml
@@ -2,12 +2,4 @@
 # 默认共享 MCP 定义统一维护在 group_vars/all/agent_mcps/servers.yml 的 agent_mcps 下。
 # 这里仅放 Gemini 特有的覆盖项；会在渲染 ~/.gemini/settings.json 前与共享配置递归合并。
 
-gemini_mcp_servers:
-  # 共享默认 MCP 已移除 context7 / deepwiki；Gemini 继续通过本文件保留这两个默认能力。
-  context7:
-    type: "stdio"
-    command: "npx"
-    args: ["-y", "@upstash/context7-mcp"]
-  deepwiki:
-    type: "http"
-    url: "https://mcp.deepwiki.com/mcp"
+gemini_mcp_servers: {}

--- a/inventory/default/group_vars/all/opencommit/settings.yml
+++ b/inventory/default/group_vars/all/opencommit/settings.yml
@@ -6,4 +6,4 @@
 opencommit_settings:
   OCO_EMOJI: true
   OCO_DESCRIPTION: false
-  OCO_LANGUAGE: zh-CN
+  OCO_LANGUAGE: zh_CN

--- a/roles/agent_codex/README.md
+++ b/roles/agent_codex/README.md
@@ -54,11 +54,17 @@ agent_codex_config:
       wire_api: responses
       env_key: PPIO_API_KEY
   mcp_servers:
-    context7:
+    mcp-server-fetch:
+      command: uvx
+      args:
+        - mcp-server-fetch
+    codecov:
       command: npx
       args:
         - -y
-        - '@upstash/context7-mcp'
+        - '@egulatee/mcp-codecov'
+      env:
+        CODECOV_BASE_URL: https://codecov.io
 ```
 
 ## 输出
@@ -104,10 +110,17 @@ agent_codex_result:
               wire_api: responses
               env_key: PPIO_API_KEY
           mcp_servers:
-            fetch:
+            mcp-server-fetch:
               command: uvx
               args:
                 - mcp-server-fetch
+            codecov:
+              command: npx
+              args:
+                - -y
+                - '@egulatee/mcp-codecov'
+              env:
+                CODECOV_BASE_URL: https://codecov.io
         agent_codex_env:
           PPIO_API_KEY: "{{ vault_ppio_api_key }}"
         agent_codex_agents_md_src: "{{ playbook_dir }}/files/AGENTS.md"

--- a/roles/agent_codex/molecule/default/converge.yml
+++ b/roles/agent_codex/molecule/default/converge.yml
@@ -81,17 +81,34 @@
               wire_api: responses
               env_key: PPIO_API_KEY
           mcp_servers:
-            context7:
-              command: npx
-              args:
-                - -y
-                - '@upstash/context7-mcp'
-            fetch:
+            mcp-server-fetch:
               command: uvx
               args:
                 - mcp-server-fetch
-            deepwiki:
-              url: https://mcp.deepwiki.com/mcp
+            open-websearch:
+              command: npx
+              args:
+                - -y
+                - open-websearch@latest
+              env:
+                MODE: stdio
+                DEFAULT_SEARCH_ENGINE: duckduckgo
+                ALLOWED_SEARCH_ENGINES: duckduckgo,bing,brave
+            codecov:
+              command: npx
+              args:
+                - -y
+                - '@egulatee/mcp-codecov'
+              env:
+                CODECOV_BASE_URL: https://codecov.io
+            serena:
+              command: uvx
+              args:
+                - --from
+                - git+https://github.com/oraios/serena
+                - serena
+                - start-mcp-server
+              startup_timeout_sec: 20
         agent_codex_env:
           PPIO_API_KEY: test-key
         agent_codex_agents_md_src: "{{ playbook_dir }}/files/AGENTS.md"

--- a/roles/agent_codex/molecule/default/verify.yml
+++ b/roles/agent_codex/molecule/default/verify.yml
@@ -30,17 +30,34 @@
               wire_api: responses
               env_key: PPIO_API_KEY
           mcp_servers:
-            context7:
-              command: npx
-              args:
-                - -y
-                - '@upstash/context7-mcp'
-            fetch:
+            mcp-server-fetch:
               command: uvx
               args:
                 - mcp-server-fetch
-            deepwiki:
-              url: https://mcp.deepwiki.com/mcp
+            open-websearch:
+              command: npx
+              args:
+                - -y
+                - open-websearch@latest
+              env:
+                MODE: stdio
+                DEFAULT_SEARCH_ENGINE: duckduckgo
+                ALLOWED_SEARCH_ENGINES: duckduckgo,bing,brave
+            codecov:
+              command: npx
+              args:
+                - -y
+                - '@egulatee/mcp-codecov'
+              env:
+                CODECOV_BASE_URL: https://codecov.io
+            serena:
+              command: uvx
+              args:
+                - --from
+                - git+https://github.com/oraios/serena
+                - serena
+                - start-mcp-server
+              startup_timeout_sec: 20
         agent_codex_env:
           PPIO_API_KEY: test-key
         agent_codex_agents_md_src: "{{ playbook_dir }}/files/AGENTS.md"
@@ -79,9 +96,11 @@
           - (agent_codex_config_final.stdout | from_json).sandbox_mode == 'read-only'
           - (agent_codex_config_final.stdout | from_json).history.persistence == 'save-all'
           - (agent_codex_config_final.stdout | from_json).model_providers.ppio.env_key == 'PPIO_API_KEY'
-          - (agent_codex_config_final.stdout | from_json).mcp_servers.context7.command == 'npx'
-          - (agent_codex_config_final.stdout | from_json).mcp_servers.fetch.args == ['mcp-server-fetch']
-          - (agent_codex_config_final.stdout | from_json).mcp_servers.deepwiki.url == 'https://mcp.deepwiki.com/mcp'
+          - (agent_codex_config_final.stdout | from_json).mcp_servers['mcp-server-fetch'].args == ['mcp-server-fetch']
+          - (agent_codex_config_final.stdout | from_json).mcp_servers.open-websearch.env.MODE == 'stdio'
+          - (agent_codex_config_final.stdout | from_json).mcp_servers.codecov.args == ['-y', '@egulatee/mcp-codecov']
+          - (agent_codex_config_final.stdout | from_json).mcp_servers.codecov.env.CODECOV_BASE_URL == 'https://codecov.io'
+          - (agent_codex_config_final.stdout | from_json).mcp_servers.serena.startup_timeout_sec == 20
           - >-
             ((agent_codex_config_final.stdout | from_json).get('projects', {})).get('/tmp/agent-codex/default/workspace', {}).get('trust_level')
             == 'trusted'

--- a/roles/agent_copilot_cli/README.md
+++ b/roles/agent_copilot_cli/README.md
@@ -34,21 +34,24 @@
 ```yaml
 agent_copilot_cli_mcp_config:
   mcpServers:
-    context7:
+    mcp-server-fetch:
+      type: stdio
+      command: uvx
+      args:
+        - mcp-server-fetch
+      env: {}
+      tools:
+        - "*"
+    codecov:
       type: stdio
       command: npx
       args:
         - -y
-        - '@upstash/context7-mcp'
-      env: {}
+        - '@egulatee/mcp-codecov'
+      env:
+        CODECOV_BASE_URL: https://codecov.io
       tools:
         - "*"
-    deepwiki:
-      type: http
-      url: https://mcp.deepwiki.com/mcp
-      headers: {}
-      tools:
-        - read_page
 ```
 
 ## 输出
@@ -74,12 +77,11 @@ agent_copilot_cli_result:
       vars:
         agent_copilot_cli_mcp_config:
           mcpServers:
-            context7:
+            mcp-server-fetch:
               type: stdio
-              command: npx
+              command: uvx
               args:
-                - -y
-                - '@upstash/context7-mcp'
+                - mcp-server-fetch
               env: {}
               tools:
                 - "*"
@@ -93,6 +95,16 @@ agent_copilot_cli_result:
                 MODE: stdio
               tools:
                 - search
+            codecov:
+              type: stdio
+              command: npx
+              args:
+                - -y
+                - '@egulatee/mcp-codecov'
+              env:
+                CODECOV_BASE_URL: https://codecov.io
+              tools:
+                - "*"
 ```
 
 ## 说明

--- a/roles/agent_copilot_cli/molecule/default/converge.yml
+++ b/roles/agent_copilot_cli/molecule/default/converge.yml
@@ -59,27 +59,45 @@
               tools:
                 - legacy_tool
                 - extra_tool
-            context7:
+            mcp-server-fetch:
+              type: stdio
+              command: uvx
+              args:
+                - mcp-server-fetch
+              env: {}
+              tools:
+                - "*"
+            open-websearch:
               type: stdio
               command: npx
               args:
                 - -y
-                - '@upstash/context7-mcp'
-              env: {}
+                - open-websearch@latest
+              env:
+                MODE: stdio
+                DEFAULT_SEARCH_ENGINE: duckduckgo
+                ALLOWED_SEARCH_ENGINES: duckduckgo,bing,brave
               tools:
-                - "*"
-            deepwiki:
-              type: http
-              url: https://mcp.deepwiki.com/mcp
-              headers: {}
-              tools:
-                - read_page
-            playwright:
+                - search
+            codecov:
               type: stdio
               command: npx
               args:
-                - '@playwright/mcp@latest'
-              env: {}
-              cwd: /workspace
+                - -y
+                - '@egulatee/mcp-codecov'
+              env:
+                CODECOV_BASE_URL: https://codecov.io
               tools:
                 - "*"
+            serena:
+              type: stdio
+              command: uvx
+              args:
+                - --from
+                - git+https://github.com/oraios/serena
+                - serena
+                - start-mcp-server
+              tools:
+                - "*"
+              env: {}
+              startup_timeout_sec: 20

--- a/roles/agent_copilot_cli/molecule/default/verify.yml
+++ b/roles/agent_copilot_cli/molecule/default/verify.yml
@@ -20,30 +20,48 @@
               tools:
                 - legacy_tool
                 - extra_tool
-            context7:
+            mcp-server-fetch:
+              type: stdio
+              command: uvx
+              args:
+                - mcp-server-fetch
+              env: {}
+              tools:
+                - "*"
+            open-websearch:
               type: stdio
               command: npx
               args:
                 - -y
-                - '@upstash/context7-mcp'
-              env: {}
+                - open-websearch@latest
+              env:
+                MODE: stdio
+                DEFAULT_SEARCH_ENGINE: duckduckgo
+                ALLOWED_SEARCH_ENGINES: duckduckgo,bing,brave
               tools:
-                - "*"
-            deepwiki:
-              type: http
-              url: https://mcp.deepwiki.com/mcp
-              headers: {}
-              tools:
-                - read_page
-            playwright:
+                - search
+            codecov:
               type: stdio
               command: npx
               args:
-                - '@playwright/mcp@latest'
-              env: {}
-              cwd: /workspace
+                - -y
+                - '@egulatee/mcp-codecov'
+              env:
+                CODECOV_BASE_URL: https://codecov.io
               tools:
                 - "*"
+            serena:
+              type: stdio
+              command: uvx
+              args:
+                - --from
+                - git+https://github.com/oraios/serena
+                - serena
+                - start-mcp-server
+              tools:
+                - "*"
+              env: {}
+              startup_timeout_sec: 20
 
     - name: 解析最终 mcp-config.json
       command:
@@ -61,11 +79,11 @@
           - not (agent_copilot_cli_result.changed | bool)
           - (agent_copilot_cli_mcp_config_final.stdout | from_json).mcpServers.legacy.command == 'python3'
           - (agent_copilot_cli_mcp_config_final.stdout | from_json).mcpServers.legacy.tools == ['legacy_tool', 'extra_tool']
-          - (agent_copilot_cli_mcp_config_final.stdout | from_json).mcpServers.context7.type == 'stdio'
-          - (agent_copilot_cli_mcp_config_final.stdout | from_json).mcpServers.context7.args == ['-y', '@upstash/context7-mcp']
-          - (agent_copilot_cli_mcp_config_final.stdout | from_json).mcpServers.context7.tools == ['*']
-          - (agent_copilot_cli_mcp_config_final.stdout | from_json).mcpServers.deepwiki.url == 'https://mcp.deepwiki.com/mcp'
-          - (agent_copilot_cli_mcp_config_final.stdout | from_json).mcpServers.deepwiki.tools == ['read_page']
-          - (agent_copilot_cli_mcp_config_final.stdout | from_json).mcpServers.playwright.cwd == '/workspace'
+          - (agent_copilot_cli_mcp_config_final.stdout | from_json).mcpServers['mcp-server-fetch'].command == 'uvx'
+          - (agent_copilot_cli_mcp_config_final.stdout | from_json).mcpServers['mcp-server-fetch'].tools == ['*']
+          - (agent_copilot_cli_mcp_config_final.stdout | from_json).mcpServers['open-websearch'].env.MODE == 'stdio'
+          - (agent_copilot_cli_mcp_config_final.stdout | from_json).mcpServers['open-websearch'].tools == ['search']
+          - (agent_copilot_cli_mcp_config_final.stdout | from_json).mcpServers.codecov.env.CODECOV_BASE_URL == 'https://codecov.io'
+          - (agent_copilot_cli_mcp_config_final.stdout | from_json).mcpServers.serena.startup_timeout_sec == 20
         fail_msg: "agent_copilot_cli 场景验证失败"
         success_msg: "✓ agent_copilot_cli 场景通过"

--- a/roles/agent_cursor/README.md
+++ b/roles/agent_cursor/README.md
@@ -33,15 +33,18 @@
 ```yaml
 agent_cursor_mcp_config:
   mcpServers:
-    context7:
+    mcp-server-fetch:
+      command: uvx
+      args:
+        - mcp-server-fetch
+      env: {}
+    codecov:
       command: npx
       args:
         - -y
-        - '@upstash/context7-mcp'
-      env: {}
-    deepwiki:
-      url: https://mcp.deepwiki.com/mcp
-      headers: {}
+        - '@egulatee/mcp-codecov'
+      env:
+        CODECOV_BASE_URL: https://codecov.io
 ```
 
 也可以使用 Cursor 额外支持的字段，例如：
@@ -85,12 +88,13 @@ agent_cursor_result:
               autoApprove:
                 - get_issue
                 - list_pull_requests
-            context7:
+            codecov:
               command: npx
               args:
                 - -y
-                - '@upstash/context7-mcp'
-              env: {}
+                - '@egulatee/mcp-codecov'
+              env:
+                CODECOV_BASE_URL: https://codecov.io
 ```
 
 ## 说明

--- a/roles/agent_cursor/molecule/default/converge.yml
+++ b/roles/agent_cursor/molecule/default/converge.yml
@@ -56,21 +56,32 @@
             legacy:
               env:
                 MODE: stdio
-            context7:
+            mcp-server-fetch:
+              command: uvx
+              args:
+                - mcp-server-fetch
+              env: {}
+            open-websearch:
               command: npx
               args:
                 - -y
-                - '@upstash/context7-mcp'
-              env: {}
-              autoApprove:
-                - resolve-library-id
-            deepwiki:
-              url: https://mcp.deepwiki.com/mcp
-              headers: {}
-              disabled: false
-            playwright:
+                - open-websearch@latest
+              env:
+                MODE: stdio
+                DEFAULT_SEARCH_ENGINE: duckduckgo
+                ALLOWED_SEARCH_ENGINES: duckduckgo,bing,brave
+            codecov:
               command: npx
               args:
-                - '@playwright/mcp@latest'
-              env: {}
-              cwd: /workspace
+                - -y
+                - '@egulatee/mcp-codecov'
+              env:
+                CODECOV_BASE_URL: https://codecov.io
+            serena:
+              command: uvx
+              args:
+                - --from
+                - git+https://github.com/oraios/serena
+                - serena
+                - start-mcp-server
+              startup_timeout_sec: 20

--- a/roles/agent_cursor/molecule/default/verify.yml
+++ b/roles/agent_cursor/molecule/default/verify.yml
@@ -19,24 +19,35 @@
             legacy:
               env:
                 MODE: stdio
-            context7:
+            mcp-server-fetch:
+              command: uvx
+              args:
+                - mcp-server-fetch
+              env: {}
+            open-websearch:
               command: npx
               args:
                 - -y
-                - '@upstash/context7-mcp'
-              env: {}
-              autoApprove:
-                - resolve-library-id
-            deepwiki:
-              url: https://mcp.deepwiki.com/mcp
-              headers: {}
-              disabled: false
-            playwright:
+                - open-websearch@latest
+              env:
+                MODE: stdio
+                DEFAULT_SEARCH_ENGINE: duckduckgo
+                ALLOWED_SEARCH_ENGINES: duckduckgo,bing,brave
+            codecov:
               command: npx
               args:
-                - '@playwright/mcp@latest'
-              env: {}
-              cwd: /workspace
+                - -y
+                - '@egulatee/mcp-codecov'
+              env:
+                CODECOV_BASE_URL: https://codecov.io
+            serena:
+              command: uvx
+              args:
+                - --from
+                - git+https://github.com/oraios/serena
+                - serena
+                - start-mcp-server
+              startup_timeout_sec: 20
 
     - name: 解析最终 mcp.json
       command:
@@ -55,10 +66,10 @@
           - (agent_cursor_mcp_config_final.stdout | from_json).mcpServers.legacy.command == 'python3'
           - (agent_cursor_mcp_config_final.stdout | from_json).mcpServers.legacy.args == ['-m', 'legacy']
           - (agent_cursor_mcp_config_final.stdout | from_json).mcpServers.legacy.env.MODE == 'stdio'
-          - (agent_cursor_mcp_config_final.stdout | from_json).mcpServers.context7.command == 'npx'
-          - (agent_cursor_mcp_config_final.stdout | from_json).mcpServers.context7.autoApprove == ['resolve-library-id']
-          - (agent_cursor_mcp_config_final.stdout | from_json).mcpServers.deepwiki.url == 'https://mcp.deepwiki.com/mcp'
-          - (agent_cursor_mcp_config_final.stdout | from_json).mcpServers.deepwiki.disabled == false
-          - (agent_cursor_mcp_config_final.stdout | from_json).mcpServers.playwright.cwd == '/workspace'
+          - (agent_cursor_mcp_config_final.stdout | from_json).mcpServers['mcp-server-fetch'].command == 'uvx'
+          - (agent_cursor_mcp_config_final.stdout | from_json).mcpServers['open-websearch'].env.MODE == 'stdio'
+          - (agent_cursor_mcp_config_final.stdout | from_json).mcpServers.codecov.args == ['-y', '@egulatee/mcp-codecov']
+          - (agent_cursor_mcp_config_final.stdout | from_json).mcpServers.codecov.env.CODECOV_BASE_URL == 'https://codecov.io'
+          - (agent_cursor_mcp_config_final.stdout | from_json).mcpServers.serena.startup_timeout_sec == 20
         fail_msg: "agent_cursor 场景验证失败"
         success_msg: "✓ agent_cursor 场景通过"

--- a/roles/opencommit_cli/README.md
+++ b/roles/opencommit_cli/README.md
@@ -54,7 +54,7 @@ opencommit_cli_result:
           OCO_MODEL: pa/gpt-5.4
           OCO_EMOJI: true
           OCO_DESCRIPTION: false
-          OCO_LANGUAGE: zh-CN
+          OCO_LANGUAGE: zh_CN
 ```
 
 ## 说明

--- a/roles/opencommit_cli/molecule/default/converge.yml
+++ b/roles/opencommit_cli/molecule/default/converge.yml
@@ -51,7 +51,7 @@
           OCO_MODEL: pa/gpt-5.4
           OCO_EMOJI: true
           OCO_DESCRIPTION: false
-          OCO_LANGUAGE: zh-CN
+          OCO_LANGUAGE: zh_CN
           OCO_API_CUSTOM_HEADERS:
             X-Test: "yes"
 

--- a/roles/opencommit_cli/molecule/default/verify.yml
+++ b/roles/opencommit_cli/molecule/default/verify.yml
@@ -22,7 +22,7 @@
           OCO_MODEL: pa/gpt-5.4
           OCO_EMOJI: true
           OCO_DESCRIPTION: false
-          OCO_LANGUAGE: zh-CN
+          OCO_LANGUAGE: zh_CN
           OCO_API_CUSTOM_HEADERS:
             X-Test: "yes"
 
@@ -58,7 +58,7 @@
           - (opencommit_cli_config_final.stdout | from_json).OCO_MODEL == 'pa/gpt-5.4'
           - (opencommit_cli_config_final.stdout | from_json).OCO_EMOJI | bool
           - not ((opencommit_cli_config_final.stdout | from_json).OCO_DESCRIPTION | bool)
-          - (opencommit_cli_config_final.stdout | from_json).OCO_LANGUAGE == 'zh-CN'
+          - (opencommit_cli_config_final.stdout | from_json).OCO_LANGUAGE == 'zh_CN'
           - (opencommit_cli_config_final.stdout | from_json).OCO_API_CUSTOM_HEADERS['X-Test'] == 'yes'
         fail_msg: "opencommit_cli 场景验证失败"
         success_msg: "✓ opencommit_cli 场景通过"

--- a/tests/test_inventory_defaults_cleanup.py
+++ b/tests/test_inventory_defaults_cleanup.py
@@ -59,6 +59,7 @@ class InventoryDefaultsStructureTests(unittest.TestCase):
                 "TaskUpdate",
             }.issubset(set(allow))
         )
+        self.assertNotIn("mcp__context7__resolve-library-id", allow)
 
     def test_gemini_settings_do_not_repeat_runtime_control_vars(self) -> None:
         text = (REPO_ROOT / "inventory/default/group_vars/all/gemini_cli/settings.yml").read_text(encoding="utf-8")
@@ -97,6 +98,105 @@ class InventoryDefaultsStructureTests(unittest.TestCase):
             "cursor_run_verify",
         ]:
             self.assertNotIn(needle, text, msg=needle)
+
+    def test_opencommit_defaults_use_underscore_language_code(self) -> None:
+        settings = yaml.safe_load(
+            (REPO_ROOT / "inventory/default/group_vars/all/opencommit/settings.yml").read_text(encoding="utf-8")
+        )
+
+        self.assertEqual(settings["opencommit_settings"]["OCO_LANGUAGE"], "zh_CN")
+
+    def test_claude_default_models_include_optional_volces_ark_code_latest(self) -> None:
+        models = yaml.safe_load(
+            (REPO_ROOT / "inventory/default/group_vars/all/claude_code/models.yml").read_text(encoding="utf-8")
+        )
+
+        self.assertEqual(models["claude_code_use_model"], "qiniu_step_3_5_flash")
+        self.assertEqual(
+            models["claude_code_model_configs"]["volces_ark_code_latest"],
+            {
+                "base_url": "{{ private_variables.volces_api_base_url }}",
+                "api_key": "{{ (secrets | default({})).get('api_keys', {}).get('volces', '') }}",
+                "model": "ark-code-latest",
+            },
+        )
+
+    def test_default_agent_skills_extract_shared_agents_and_generic_skills(self) -> None:
+        config = yaml.safe_load(
+            (REPO_ROOT / "inventory/default/group_vars/all/agent_skills/items.yml").read_text(encoding="utf-8")
+        )
+
+        self.assertEqual(
+            config["agent_skills_default_agents"],
+            ["claude-code", "codex", "github-copilot", "cursor"],
+        )
+
+        items_by_source = {item["source"]: item for item in config["agent_skills_items"]}
+
+        for source in [
+            "anthropics/skills",
+            "obra/superpowers",
+            "vercel-labs/skills",
+            "github/awesome-copilot",
+            "upstash/context7",
+            "davidkiss/smart-ai-skills",
+            "aahl/skills",
+            "microsoft/playwright-cli",
+        ]:
+            self.assertEqual(items_by_source[source]["agents"], "{{ agent_skills_default_agents }}", msg=source)
+
+        self.assertEqual(items_by_source["upstash/context7"]["skills"], ["context7-cli"])
+        self.assertEqual(items_by_source["davidkiss/smart-ai-skills"]["skills"], ["reflection"])
+        self.assertEqual(items_by_source["aahl/skills"]["skills"], ["mcp-deepwiki"])
+        self.assertEqual(items_by_source["microsoft/playwright-cli"]["skills"], ["playwright-cli"])
+        self.assertNotIn("gemini-cli", config["agent_skills_default_agents"])
+
+    def test_default_shared_mcps_keep_only_remaining_common_services(self) -> None:
+        config = yaml.safe_load(
+            (REPO_ROOT / "inventory/default/group_vars/all/agent_mcps/servers.yml").read_text(encoding="utf-8")
+        )
+
+        agent_mcps = config["agent_mcps"]
+
+        self.assertNotIn("context7", agent_mcps)
+        self.assertNotIn("deepwiki", agent_mcps)
+        self.assertNotIn("playwright", agent_mcps)
+        self.assertNotIn("mcp-server-askecho-search-infinity", agent_mcps)
+        self.assertIn("mcp-server-fetch", agent_mcps)
+        self.assertIn("open-websearch", agent_mcps)
+        self.assertIn("serena", agent_mcps)
+        self.assertEqual(
+            agent_mcps["codecov"],
+            {
+                "type": "stdio",
+                "command": "npx",
+                "args": ["-y", "@egulatee/mcp-codecov"],
+                "env": {
+                    "CODECOV_BASE_URL": "https://codecov.io",
+                    "CODECOV_TOKEN": "{{ (secrets | default({})).get('codecov_token', '') }}",
+                },
+            },
+        )
+
+    def test_gemini_default_mcp_overrides_preserve_context7_and_deepwiki(self) -> None:
+        config = yaml.safe_load(
+            (REPO_ROOT / "inventory/default/group_vars/all/gemini_cli/mcp_servers.yml").read_text(encoding="utf-8")
+        )
+
+        self.assertEqual(
+            config["gemini_mcp_servers"],
+            {
+                "context7": {
+                    "type": "stdio",
+                    "command": "npx",
+                    "args": ["-y", "@upstash/context7-mcp"],
+                },
+                "deepwiki": {
+                    "type": "http",
+                    "url": "https://mcp.deepwiki.com/mcp",
+                },
+            },
+        )
 
 
 class MinimalInventoryPlaybookTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- migrate default context7/deepwiki/playwright integrations from shared MCP config into shared skill installs for claude-code, codex, github-copilot, and cursor
- add reusable default skill agents, shared codecov MCP, and preserve Gemini's context7/deepwiki access via gemini-specific MCP overrides
- refresh related defaults, tests, role examples, molecule expectations, and supporting repo config updates from private-config

## Test Plan
- [x] uv run python -m unittest tests.test_inventory_defaults_cleanup -q
- [x] uv run ansible-playbook -i inventory/default/inventory.yml --syntax-check playbooks/setup_agent_skills.yml
- [x] uv run ansible-playbook -i inventory/default/inventory.yml --syntax-check playbooks/setup_codex.yml
- [x] uv run ansible-playbook -i inventory/default/inventory.yml --syntax-check playbooks/setup_copilot_cli.yml
- [x] uv run ansible-playbook -i inventory/default/inventory.yml --syntax-check playbooks/setup_cursor.yml
- [x] uv run ansible-playbook -i inventory/default/inventory.yml --syntax-check playbooks/setup_gemini_cli.yml
- [x] uv run ansible-playbook -i inventory/default/inventory.yml --syntax-check playbooks/setup_claude_code.yml
- [x] uv run ansible-playbook -i inventory/default/inventory.yml --syntax-check playbooks/setup_opencommit.yml
- [x] uv run ansible-playbook -i localhost, --syntax-check roles/opencommit_cli/molecule/default/converge.yml
- [x] uv run ansible-playbook -i localhost, --syntax-check roles/opencommit_cli/molecule/default/verify.yml