### PR TITLE
feat: enable strict MCP cleanup for Claude/Copilot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ opencommit_cli
 
 agent_copilot_cli
   ├── npm_command_bootstrap
-  └── managed_json_merge
+  └── managed_file
 
 agent_cursor
   ├── npm_command_bootstrap
@@ -176,6 +176,7 @@ tmps/                          # 本地执行时的默认备份和日志目录
 - `setup_gemini_cli.yml` 会把 `gemini_cli/settings.yml`、`models.yml`、`agent_mcps/servers.yml` 和 `gemini_cli/mcp_servers.yml` 归一化成单个 `agent_gemini_cli_settings` / `agent_gemini_cli_env` 输入。
 - `setup_opencommit.yml` 会把 `opencommit/settings.yml` 与 `models.yml` 归一化成单个 `opencommit_cli_config` 输入，并同步到 `~/.opencommit`。
 - `setup_copilot_cli.yml` 当前只管理 `~/.copilot/mcp-config.json`，不负责 Copilot CLI 账号、模型或其他偏好设置。
+- Copilot CLI 的 `mcpServers` 默认使用严格替换模式（`replace`）以清理未声明条目；如需兼容旧行为可设置 `copilot_cli_mcp_servers_mode: merge`。
 - `setup_cursor.yml` 当前只管理 `~/.cursor/mcp.json`，供 Cursor 编辑器与 Cursor Agent CLI 共享使用，不负责账号、模型或其他偏好设置。
 - `managed_agent_skills` 的 `source` 必须对目标机可见；仓库内路径通常只适用于 `ansible_connection=local`。
 - `ansible.cfg` 中启用了 `any_errors_fatal = True` 和 `gathering = explicit`，所以失败会立刻终止，facts 也不会默认收集。

--- a/inventory/default/group_vars/all/claude_code/mcp_servers.yml
+++ b/inventory/default/group_vars/all/claude_code/mcp_servers.yml
@@ -1,6 +1,6 @@
-# ===== claude.json 增量合并配置 =====
-# 以下配置会递归深度合并到 ~/.claude.json
-# 仅覆盖声明的 key，未声明的保持原样
+# ===== claude.json MCP 配置 =====
+# 默认仅对 ~/.claude.json.mcpServers 做严格替换（删除未声明条目）。
+# 如需兼容旧行为，可设 claude_code_mcp_servers_mode: merge。
 # 默认共享 MCP 定义统一维护在 group_vars/all/agent_mcps/servers.yml 的 agent_mcps 下。
 # 如需仅对 Claude Code 覆盖或补充某个服务，可在下方 mcpServers 中声明同名项。
 # 用户 JSON 同步前是否确认由顶层变量 `claude_code_confirm_user_json_update` 控制，
@@ -16,6 +16,8 @@
 #         env: {...}                    # stdio 类型（可选）
 #         url: ...                      # http 类型
 #         headers: {...}               # http 类型（可选）
+
+claude_code_mcp_servers_mode: replace
 
 claude_code_dot_claude_json_merge:
   # 仅放 Claude Code 特有的 MCP 覆盖项；默认共享配置由 agent_mcps 注入

--- a/inventory/default/group_vars/all/copilot_cli/mcp_servers.yml
+++ b/inventory/default/group_vars/all/copilot_cli/mcp_servers.yml
@@ -1,9 +1,13 @@
 # GitHub Copilot CLI MCP 覆盖配置
 # 默认共享 MCP 定义统一维护在 group_vars/all/agent_mcps/servers.yml 的 agent_mcps 下。
 # 这里仅放 Copilot CLI 特有的覆盖项；会在渲染 ~/.copilot/mcp-config.json 前与共享配置递归合并。
+# 默认仅对 mcp-config.json.mcpServers 做严格替换（删除未声明条目）。
+# 如需兼容旧行为，可设 copilot_cli_mcp_servers_mode: merge。
 #
 # Copilot CLI 额外支持的常用字段：
 #   tools: ["*"] 或显式工具名列表
 #   cwd:   仅对 local/stdio 生效的工作目录
+
+copilot_cli_mcp_servers_mode: replace
 
 copilot_cli_mcp_servers: {}

--- a/playbooks/setup_claude_code.yml
+++ b/playbooks/setup_claude_code.yml
@@ -95,10 +95,11 @@
           - (claude_code_settings.enabled_plugins | default([])) is sequence
           - (claude_code_settings.enabled_plugins | default([])) is not string
           - (claude_code_dot_claude_json_merge.mcpServers | default({})) is mapping
+          - (claude_code_mcp_servers_mode | default('replace') | lower) in ['merge', 'replace']
         fail_msg: >-
           Claude Code 编排输入无效：请检查 claude_code/settings.yml、models.yml、
           agent_mcps/servers.yml、claude_code/mcp_servers.yml 中的变量结构，
-          尤其是 claude_code_use_model、enabled_plugins 与 mcpServers。
+          尤其是 claude_code_use_model、enabled_plugins、mcpServers 与 claude_code_mcp_servers_mode。
       tags:
         - always
 
@@ -139,6 +140,7 @@
           }}
         claude_code_confirm_settings_update_effective: "{{ claude_code_confirm_settings_update | default(true) }}"
         claude_code_confirm_user_json_update_effective: "{{ claude_code_confirm_user_json_update | default(true) }}"
+        claude_code_mcp_servers_mode_effective: "{{ claude_code_mcp_servers_mode | default('replace') | lower }}"
         claude_code_settings_effective: >-
           {{
             (
@@ -219,6 +221,7 @@
         agent_claude_code_settings_schemafile: "{{ claude_code_settings_schemafile | default('https://json.schemastore.org/claude-code-settings.json') }}"
         agent_claude_code_confirm_settings_update: "{{ claude_code_confirm_settings_update_effective | bool }}"
         agent_claude_code_confirm_user_json_update: "{{ claude_code_confirm_user_json_update_effective | bool }}"
+        agent_claude_code_mcp_servers_mode: "{{ claude_code_mcp_servers_mode_effective }}"
         agent_claude_code_backup: "{{ claude_code_backup | default(true) | bool }}"
         agent_claude_code_backup_root: "{{ claude_code_backup_root_effective }}"
         agent_claude_code_plugin_marketplaces: "{{ claude_code_plugin_marketplaces_effective }}"

--- a/playbooks/setup_copilot_cli.yml
+++ b/playbooks/setup_copilot_cli.yml
@@ -57,16 +57,18 @@
           - (copilot_cli_mcp_servers | default({})) is mapping
           - (copilot_cli_default_tools | default(['*'])) is sequence
           - (copilot_cli_default_tools | default(['*'])) is not string
+          - (copilot_cli_mcp_servers_mode | default('replace') | lower) in ['merge', 'replace']
         fail_msg: >-
           Copilot CLI 编排输入无效：请检查 agent_mcps/servers.yml 与
           copilot_cli/settings.yml、copilot_cli/mcp_servers.yml 中的变量结构，
-          尤其是 agent_mcps、copilot_cli_mcp_servers 与 copilot_cli_default_tools。
+          尤其是 agent_mcps、copilot_cli_mcp_servers、copilot_cli_default_tools 与 copilot_cli_mcp_servers_mode。
       tags:
         - always
 
     - name: 初始化 Copilot CLI MCP 配置
       set_fact:
         copilot_cli_mcp_servers_effective: {}
+        copilot_cli_mcp_servers_mode_effective: "{{ copilot_cli_mcp_servers_mode | default('replace') | lower }}"
       tags:
         - always
 
@@ -190,6 +192,7 @@
         agent_copilot_cli_confirm_mcp_config_update: "{{ copilot_cli_confirm_mcp_config_update | default(true) | bool }}"
         agent_copilot_cli_backup: "{{ copilot_cli_backup | default(true) | bool }}"
         agent_copilot_cli_backup_root: "{{ copilot_cli_backup_root_effective }}"
+        agent_copilot_cli_mcp_servers_mode: "{{ copilot_cli_mcp_servers_mode_effective }}"
         agent_copilot_cli_mcp_config:
           mcpServers: "{{ copilot_cli_mcp_servers_effective }}"
       tags:

--- a/roles/agent_claude_code/README.md
+++ b/roles/agent_claude_code/README.md
@@ -4,7 +4,7 @@
 
 - 检查 Claude CLI 与可选的 `ccline`，支持 Claude CLI 缺失时自动安装
 - 管理插件 marketplace 与插件安装
-- deep merge `~/.claude.json`
+- 同步 `~/.claude.json`（默认仅对 `mcpServers` 做严格替换，其他字段保持合并语义）
 - 生成并同步 `~/.claude/settings.json`
 - 按需同步外部 `output-styles` 和 `CLAUDE.md`
 
@@ -44,7 +44,8 @@
 | `agent_claude_code_plugin_marketplaces` | ❌ | 内置官方 marketplace | 插件 marketplace 名称到 URL 的映射 |
 | `agent_claude_code_plugins_to_install` | ❌ | `[]` | 显式安装的插件列表；为空时回退到 `settings.enabledPlugins` |
 | `agent_claude_code_settings` | ✅ | 见 defaults | 用于生成 `settings.json` 的配置对象 |
-| `agent_claude_code_user_json` | ❌ | `hasCompletedOnboarding + 空 mcpServers` | 将被 deep merge 到 `~/.claude.json` 的对象 |
+| `agent_claude_code_mcp_servers_mode` | ❌ | `replace` | `replace`：严格替换 `mcpServers`；`merge`：增量合并 `mcpServers` |
+| `agent_claude_code_user_json` | ❌ | `hasCompletedOnboarding + 空 mcpServers` | 写入 `~/.claude.json` 的对象（`mcpServers` 行为受 `agent_claude_code_mcp_servers_mode` 控制） |
 | `agent_claude_code_output_styles_src` | ❌ | `""` | 外部 output-styles 目录路径；为空时不管理 |
 | `agent_claude_code_claude_md_src` | ❌ | `""` | 外部 `CLAUDE.md` 文件路径；为空时不管理 |
 | `agent_claude_code_output_styles_delete` | ❌ | `true` | 同步 output-styles 时是否删除目标端多余文件 |
@@ -146,6 +147,7 @@ agent_claude_code_result:
 - 本 role 不管理 `agents` 目录，也不会主动创建它。
 - Claude Opus 4.7+ 建议使用 `alwaysThinkingEnabled: false` 配合 `effortLevel`，避免触发已废弃的 `thinking.enabled` 请求语义。
 - `agent_claude_code_plugins_to_install` 为空时，会自动使用 `agent_claude_code_settings.enabledPlugins` 作为插件安装目标。
+- `agent_claude_code_mcp_servers_mode` 默认为 `replace`，会删除 `~/.claude.json` 中未声明的 MCP 条目；若需兼容旧行为可设为 `merge`。
 - `agent_claude_code_output_styles_src` 会自动归一化为以 `/` 结尾的目录同步语义。
 - `agent_claude_code_confirm_settings_update` 和 `agent_claude_code_confirm_user_json_update` 适用于手动执行 playbook 的交互确认；如果是无人值守执行，应保持为 `false`。
 - 设置 `agent_claude_code_backup_root` 后，`settings.json`、`~/.claude.json` 和 `CLAUDE.md` 的备份会分别写入其下的 `settings/`、`user-json/`、`claude-md/` 子目录。

--- a/roles/agent_claude_code/defaults/main.yml
+++ b/roles/agent_claude_code/defaults/main.yml
@@ -99,7 +99,10 @@ agent_claude_code_settings:
     command: ccline
     padding: 0
 
-# 将被 deep merge 到 ~/.claude.json 的对象
+# ~/.claude.json 中 mcpServers 的同步模式：replace(默认，严格替换) / merge(增量合并)
+agent_claude_code_mcp_servers_mode: replace
+
+# 将被写入 ~/.claude.json 的对象
 agent_claude_code_user_json:
   hasCompletedOnboarding: true
   mcpServers: {}

--- a/roles/agent_claude_code/molecule/default/verify.yml
+++ b/roles/agent_claude_code/molecule/default/verify.yml
@@ -107,10 +107,11 @@
           - (agent_claude_code_settings_json_final.content | b64decode | from_json).effortLevel == 'high'
           - (agent_claude_code_user_json_final.content | b64decode | from_json).untouched == true
           - (agent_claude_code_user_json_final.content | b64decode | from_json).mcpServers['local-demo'].command == 'node'
-          - (agent_claude_code_user_json_final.content | b64decode | from_json).mcpServers.existing.command == 'python3'
+          - (agent_claude_code_user_json_final.content | b64decode | from_json).mcpServers.existing is not defined
           - (agent_claude_code_user_json_final.content | b64decode | from_json).mcpServers['mcp-server-fetch'].command == 'uvx'
           - (agent_claude_code_user_json_final.content | b64decode | from_json).mcpServers['mcp-server-fetch'].args == ['mcp-server-fetch']
-          - (agent_claude_code_user_json_final.content | b64decode | from_json).mcpServers['mcp-server-fetch'].env == {}
+          - (agent_claude_code_user_json_final.content | b64decode | from_json).mcpServers['mcp-server-fetch'].env is not defined
+          - (((agent_claude_code_user_json_final.content | b64decode | from_json).mcpServers | dict2items | map(attribute='key') | list | sort) == ['local-demo', 'mcp-server-fetch'])
           - agent_claude_code_output_style_custom.stat.exists
           - not agent_claude_code_output_style_legacy.stat.exists
           - agent_claude_code_skill_legacy.stat.exists

--- a/roles/agent_claude_code/tasks/sync_user_json.yml
+++ b/roles/agent_claude_code/tasks/sync_user_json.yml
@@ -6,20 +6,83 @@
       阶段 3：同步 ~/.claude.json
       ========================================
 
-- name: 通过 deep merge 同步 ~/.claude.json
+- name: 检查现有 ~/.claude.json 是否存在
+  stat:
+    path: "{{ agent_claude_code_user_json_path }}"
+  register: agent_claude_code_user_json_existing
+
+- name: 读取现有 ~/.claude.json
+  slurp:
+    src: "{{ agent_claude_code_user_json_path }}"
+  register: agent_claude_code_user_json_existing_raw
+  when: agent_claude_code_user_json_existing.stat.exists
+
+- name: 初始化 ~/.claude.json 计算上下文
+  set_fact:
+    agent_claude_code_user_json_existing_data: >-
+      {{
+        (agent_claude_code_user_json_existing_raw.content | b64decode | from_json)
+        if agent_claude_code_user_json_existing.stat.exists
+        else {}
+      }}
+    agent_claude_code_user_json_patch_without_mcp: >-
+      {{
+        agent_claude_code_user_json_normalized
+        | dict2items
+        | rejectattr('key', 'equalto', 'mcpServers')
+        | items2dict
+      }}
+  changed_when: false
+
+- name: 校验现有 ~/.claude.json 数据结构
+  assert:
+    that:
+      - agent_claude_code_user_json_existing_data is mapping
+    fail_msg: "~/.claude.json 不是 JSON 对象，无法执行受控合并。"
+
+- name: 计算 ~/.claude.json 最终内容
+  set_fact:
+    agent_claude_code_user_json_merged_data: >-
+      {{
+        (
+          agent_claude_code_user_json_existing_data
+          | combine(agent_claude_code_user_json_patch_without_mcp, recursive=True, list_merge='replace')
+          | combine(
+              {'mcpServers': (agent_claude_code_user_json_normalized.mcpServers | default({}))},
+              recursive=False
+            )
+        )
+        if (agent_claude_code_mcp_servers_mode_normalized == 'replace')
+        else
+        (
+          agent_claude_code_user_json_existing_data
+          | combine(agent_claude_code_user_json_normalized, recursive=True, list_merge='replace')
+        )
+      }}
+  changed_when: false
+
+- name: 通过 managed_file 同步 ~/.claude.json
   include_role:
-    name: managed_json_merge
+    name: managed_file
   vars:
-    managed_json_merge_display_name: claude.json
-    managed_json_merge_dest: "{{ agent_claude_code_user_json_path }}"
-    managed_json_merge_template_src: "{{ agent_claude_code_role_path }}/templates/claude.yml.j2"
-    managed_json_merge_temp_path: "{{ agent_claude_code_temp_root }}/claude.json.rendered"
-    managed_json_merge_confirm: "{{ agent_claude_code_confirm_user_json_update }}"
-    managed_json_merge_backup: "{{ agent_claude_code_backup }}"
-    managed_json_merge_backup_dir: "{{ agent_claude_code_user_json_backup_dir }}"
-    managed_json_merge_backup_prefix: "{{ agent_claude_code_user_json_backup_prefix }}"
+    managed_file_display_name: claude.json
+    managed_file_dest: "{{ agent_claude_code_user_json_path }}"
+    managed_file_temp_path: "{{ agent_claude_code_temp_root }}/claude.json.rendered"
+    managed_file_content: "{{ (agent_claude_code_user_json_merged_data | to_nice_json(sort_keys=True)) ~ '\n' }}"
+    managed_file_mode: "0644"
+    managed_file_compare_kind: json_sorted
+    managed_file_confirm: "{{ agent_claude_code_confirm_user_json_update }}"
+    managed_file_backup: "{{ agent_claude_code_backup }}"
+    managed_file_backup_dir: "{{ agent_claude_code_user_json_backup_dir }}"
+    managed_file_backup_prefix: "{{ agent_claude_code_user_json_backup_prefix }}"
 
 - name: 记录 ~/.claude.json 同步结果
   set_fact:
-    agent_claude_code_user_json_result: "{{ managed_json_merge_result }}"
+    agent_claude_code_user_json_result:
+      changed: "{{ managed_file_result.changed | bool }}"
+      created: "{{ managed_file_result.created | bool }}"
+      backup_path: "{{ managed_file_result.backup_path }}"
+      compare_kind: "{{ managed_file_result.compare_kind }}"
+      diff: "{{ managed_file_result.diff }}"
+      merged: "{{ agent_claude_code_user_json_merged_data }}"
   changed_when: false

--- a/roles/agent_claude_code/tasks/validate.yml
+++ b/roles/agent_claude_code/tasks/validate.yml
@@ -14,6 +14,7 @@
       - agent_claude_code_temp_root | length > 0
       - agent_claude_code_settings is mapping
       - agent_claude_code_user_json is mapping
+      - (agent_claude_code_mcp_servers_mode | lower) in ['merge', 'replace']
       - agent_claude_code_plugin_marketplaces is mapping
       - agent_claude_code_plugins_to_install is sequence
       - agent_claude_code_plugins_to_install is not string
@@ -54,6 +55,7 @@
           'mcpServers': {}
         } | combine(agent_claude_code_user_json, recursive=True)
       }}
+    agent_claude_code_mcp_servers_mode_normalized: "{{ agent_claude_code_mcp_servers_mode | lower }}"
   changed_when: false
 
 - name: 校验归一化后的 Claude Code 配置

--- a/roles/agent_claude_code/tasks/verify.yml
+++ b/roles/agent_claude_code/tasks/verify.yml
@@ -112,6 +112,16 @@
     success_msg: "✓ ~/.claude.json onboarding 标记正确"
   when: agent_claude_code_manage_user_json | bool
 
+- name: 验证 mcpServers 严格替换结果
+  assert:
+    that:
+      - agent_claude_code_user_json_data.mcpServers == (agent_claude_code_user_json_normalized.mcpServers | default({}))
+    fail_msg: "~/.claude.json mcpServers 与期望不一致（replace 模式要求精确一致）"
+    success_msg: "✓ ~/.claude.json mcpServers 与期望完全一致"
+  when:
+    - agent_claude_code_manage_user_json | bool
+    - agent_claude_code_mcp_servers_mode_normalized == 'replace'
+
 - name: 验证 mcpServers 已正确合并
   assert:
     that:
@@ -130,6 +140,7 @@
     label: "{{ item.key }}"
   when:
     - agent_claude_code_manage_user_json | bool
+    - agent_claude_code_mcp_servers_mode_normalized == 'merge'
     - agent_claude_code_user_json_normalized.mcpServers | length > 0
 
 - name: 检查 output-styles 目录

--- a/roles/agent_copilot_cli/README.md
+++ b/roles/agent_copilot_cli/README.md
@@ -3,7 +3,7 @@
 复用仓库现有基础 role，为 GitHub Copilot CLI 执行一套最小但完整的 MCP 自动化配置流程：
 
 - 检查可选的 GitHub Copilot CLI 可用性
-- deep merge 并同步 `~/.copilot/mcp-config.json`
+- 同步 `~/.copilot/mcp-config.json`（默认仅对 `mcpServers` 做严格替换，其他字段保持合并语义）
 - 验证最终 MCP 配置结果
 
 当前 role 只处理 Copilot CLI 的 MCP 配置，不管理模型、认证或其他 CLI 行为设置。
@@ -11,7 +11,7 @@
 ## 依赖的基础 role
 
 - `npm_command_bootstrap`
-- `managed_json_merge`
+- `managed_file`
 
 ## 变量
 
@@ -27,7 +27,8 @@
 | `agent_copilot_cli_confirm_mcp_config_update` | ❌ | `false` | `mcp-config.json` 变更时是否交互确认 |
 | `agent_copilot_cli_backup` | ❌ | `true` | 是否为托管文件创建备份 |
 | `agent_copilot_cli_backup_root` | ❌ | `""` | 统一备份根目录；设置后会自动派生 `mcp-config/` 子目录 |
-| `agent_copilot_cli_mcp_config` | ✅ | 见 defaults | 将被 deep merge 到 `mcp-config.json` 的对象 |
+| `agent_copilot_cli_mcp_servers_mode` | ❌ | `replace` | `replace`：严格替换 `mcpServers`；`merge`：增量合并 `mcpServers` |
+| `agent_copilot_cli_mcp_config` | ✅ | 见 defaults | 写入 `mcp-config.json` 的对象（`mcpServers` 行为受 `agent_copilot_cli_mcp_servers_mode` 控制） |
 
 ## `agent_copilot_cli_mcp_config` 结构
 
@@ -109,6 +110,6 @@ agent_copilot_cli_result:
 
 ## 说明
 
-- `mcp-config.json` 使用 deep merge，同名 server 只覆盖声明的字段，未声明字段保持原样。
+- `agent_copilot_cli_mcp_servers_mode` 默认为 `replace`，会删除 `mcp-config.json` 中未声明的 MCP 条目；若需兼容旧行为可设为 `merge`。
 - 如果你希望使用仓库级 `.vscode/mcp.json`，可以覆盖 `agent_copilot_cli_mcp_config_path`；role 本身不强制限定目标路径。
 - `agent_copilot_cli_confirm_mcp_config_update` 适用于手动执行 playbook 的交互确认；如果是无人值守执行，应保持为 `false`。

--- a/roles/agent_copilot_cli/defaults/main.yml
+++ b/roles/agent_copilot_cli/defaults/main.yml
@@ -36,6 +36,9 @@ agent_copilot_cli_mcp_config_backup_dir: >-
   }}
 agent_copilot_cli_mcp_config_backup_prefix: mcp-config.json
 
-# 将被 deep merge 到 mcp-config.json 的对象
+# mcp-config.json 中 mcpServers 的同步模式：replace(默认，严格替换) / merge(增量合并)
+agent_copilot_cli_mcp_servers_mode: replace
+
+# 将被写入 mcp-config.json 的对象
 agent_copilot_cli_mcp_config:
   mcpServers: {}

--- a/roles/agent_copilot_cli/molecule/default/converge.yml
+++ b/roles/agent_copilot_cli/molecule/default/converge.yml
@@ -56,6 +56,11 @@
         agent_copilot_cli_mcp_config:
           mcpServers:
             legacy:
+              type: stdio
+              command: python3
+              args:
+                - -m
+                - legacy
               tools:
                 - legacy_tool
                 - extra_tool

--- a/roles/agent_copilot_cli/molecule/default/verify.yml
+++ b/roles/agent_copilot_cli/molecule/default/verify.yml
@@ -17,6 +17,11 @@
         agent_copilot_cli_mcp_config:
           mcpServers:
             legacy:
+              type: stdio
+              command: python3
+              args:
+                - -m
+                - legacy
               tools:
                 - legacy_tool
                 - extra_tool
@@ -85,5 +90,6 @@
           - (agent_copilot_cli_mcp_config_final.stdout | from_json).mcpServers['open-websearch'].tools == ['search']
           - (agent_copilot_cli_mcp_config_final.stdout | from_json).mcpServers.codecov.env.CODECOV_BASE_URL == 'https://codecov.io'
           - (agent_copilot_cli_mcp_config_final.stdout | from_json).mcpServers.serena.startup_timeout_sec == 20
+          - (((agent_copilot_cli_mcp_config_final.stdout | from_json).mcpServers | dict2items | map(attribute='key') | list | sort) == ['codecov', 'legacy', 'mcp-server-fetch', 'open-websearch', 'serena'])
         fail_msg: "agent_copilot_cli 场景验证失败"
         success_msg: "✓ agent_copilot_cli 场景通过"

--- a/roles/agent_copilot_cli/tasks/sync_mcp_config.yml
+++ b/roles/agent_copilot_cli/tasks/sync_mcp_config.yml
@@ -6,21 +6,83 @@
       阶段 2：同步 mcp-config.json
       ========================================
 
-- name: 通过 managed_json_merge 管理 mcp-config.json
+- name: 检查现有 mcp-config.json 是否存在
+  stat:
+    path: "{{ agent_copilot_cli_mcp_config_path }}"
+  register: agent_copilot_cli_mcp_config_existing
+
+- name: 读取现有 mcp-config.json
+  slurp:
+    src: "{{ agent_copilot_cli_mcp_config_path }}"
+  register: agent_copilot_cli_mcp_config_existing_raw
+  when: agent_copilot_cli_mcp_config_existing.stat.exists
+
+- name: 初始化 mcp-config.json 计算上下文
+  set_fact:
+    agent_copilot_cli_mcp_config_existing_data: >-
+      {{
+        (agent_copilot_cli_mcp_config_existing_raw.content | b64decode | from_json)
+        if agent_copilot_cli_mcp_config_existing.stat.exists
+        else {}
+      }}
+    agent_copilot_cli_mcp_config_patch_without_mcp: >-
+      {{
+        agent_copilot_cli_mcp_config_normalized
+        | dict2items
+        | rejectattr('key', 'equalto', 'mcpServers')
+        | items2dict
+      }}
+  changed_when: false
+
+- name: 校验现有 mcp-config.json 数据结构
+  assert:
+    that:
+      - agent_copilot_cli_mcp_config_existing_data is mapping
+    fail_msg: "mcp-config.json 不是 JSON 对象，无法执行受控合并。"
+
+- name: 计算 mcp-config.json 最终内容
+  set_fact:
+    agent_copilot_cli_mcp_config_merged_data: >-
+      {{
+        (
+          agent_copilot_cli_mcp_config_existing_data
+          | combine(agent_copilot_cli_mcp_config_patch_without_mcp, recursive=True, list_merge='replace')
+          | combine(
+              {'mcpServers': (agent_copilot_cli_mcp_config_normalized.mcpServers | default({}))},
+              recursive=False
+            )
+        )
+        if (agent_copilot_cli_mcp_servers_mode_normalized == 'replace')
+        else
+        (
+          agent_copilot_cli_mcp_config_existing_data
+          | combine(agent_copilot_cli_mcp_config_normalized, recursive=True, list_merge='replace')
+        )
+      }}
+  changed_when: false
+
+- name: 通过 managed_file 管理 mcp-config.json
   include_role:
-    name: managed_json_merge
+    name: managed_file
   vars:
-    managed_json_merge_display_name: mcp-config.json
-    managed_json_merge_dest: "{{ agent_copilot_cli_mcp_config_path }}"
-    managed_json_merge_template_src: "{{ agent_copilot_cli_role_path }}/templates/mcp-config.patch.yml.j2"
-    managed_json_merge_temp_path: "{{ agent_copilot_cli_temp_root }}/mcp-config.json.rendered"
-    managed_json_merge_mode: "0644"
-    managed_json_merge_backup: "{{ agent_copilot_cli_backup }}"
-    managed_json_merge_backup_dir: "{{ agent_copilot_cli_mcp_config_backup_dir }}"
-    managed_json_merge_backup_prefix: "{{ agent_copilot_cli_mcp_config_backup_prefix }}"
-    managed_json_merge_confirm: "{{ agent_copilot_cli_confirm_mcp_config_update }}"
+    managed_file_display_name: mcp-config.json
+    managed_file_dest: "{{ agent_copilot_cli_mcp_config_path }}"
+    managed_file_temp_path: "{{ agent_copilot_cli_temp_root }}/mcp-config.json.rendered"
+    managed_file_content: "{{ (agent_copilot_cli_mcp_config_merged_data | to_nice_json(sort_keys=True)) ~ '\n' }}"
+    managed_file_mode: "0644"
+    managed_file_compare_kind: json_sorted
+    managed_file_backup: "{{ agent_copilot_cli_backup }}"
+    managed_file_backup_dir: "{{ agent_copilot_cli_mcp_config_backup_dir }}"
+    managed_file_backup_prefix: "{{ agent_copilot_cli_mcp_config_backup_prefix }}"
+    managed_file_confirm: "{{ agent_copilot_cli_confirm_mcp_config_update }}"
 
 - name: 记录 mcp-config.json 同步结果
   set_fact:
-    agent_copilot_cli_mcp_config_result: "{{ managed_json_merge_result }}"
+    agent_copilot_cli_mcp_config_result:
+      changed: "{{ managed_file_result.changed | bool }}"
+      created: "{{ managed_file_result.created | bool }}"
+      backup_path: "{{ managed_file_result.backup_path }}"
+      compare_kind: "{{ managed_file_result.compare_kind }}"
+      diff: "{{ managed_file_result.diff }}"
+      merged: "{{ agent_copilot_cli_mcp_config_merged_data }}"
   changed_when: false

--- a/roles/agent_copilot_cli/tasks/validate.yml
+++ b/roles/agent_copilot_cli/tasks/validate.yml
@@ -13,6 +13,7 @@
       - agent_copilot_cli_mcp_config_path | length > 0
       - agent_copilot_cli_temp_root | length > 0
       - agent_copilot_cli_mcp_config is mapping
+      - (agent_copilot_cli_mcp_servers_mode | lower) in ['merge', 'replace']
     fail_msg: >-
       agent_copilot_cli 角色参数无效：请确保 home_dir / mcp_config_path /
       temp_root 非空，且 mcp_config 为对象结构。
@@ -25,6 +26,7 @@
           'mcpServers': {}
         } | combine(agent_copilot_cli_mcp_config, recursive=True)
       }}
+    agent_copilot_cli_mcp_servers_mode_normalized: "{{ agent_copilot_cli_mcp_servers_mode | lower }}"
   changed_when: false
 
 - name: 校验归一化后的 Copilot CLI MCP 配置

--- a/roles/agent_copilot_cli/tasks/verify.yml
+++ b/roles/agent_copilot_cli/tasks/verify.yml
@@ -49,6 +49,16 @@
 - name: 验证 mcpServers 已正确写入
   assert:
     that:
+      - agent_copilot_cli_mcp_config_data.mcpServers == (agent_copilot_cli_mcp_config_normalized.mcpServers | default({}))
+    fail_msg: "mcp-config.json mcpServers 与期望不一致（replace 模式要求精确一致）"
+    success_msg: "✓ mcp-config.json mcpServers 与期望完全一致"
+  when:
+    - agent_copilot_cli_manage_mcp_config | bool
+    - agent_copilot_cli_mcp_servers_mode_normalized == 'replace'
+
+- name: 验证 mcpServers 已正确写入
+  assert:
+    that:
       - agent_copilot_cli_mcp_config_data.mcpServers[item.key] is defined
       - agent_copilot_cli_mcp_config_data.mcpServers[item.key] is mapping
       - >-
@@ -64,4 +74,5 @@
     label: "{{ item.key }}"
   when:
     - agent_copilot_cli_manage_mcp_config | bool
+    - agent_copilot_cli_mcp_servers_mode_normalized == 'merge'
     - agent_copilot_cli_mcp_config_normalized.mcpServers | length > 0


### PR DESCRIPTION
## Summary\n- default Claude MCP sync to strict replace mode with merge fallback\n- default Copilot MCP sync to strict replace mode with merge fallback\n- keep non-MCP fields merged, only enforce strict replacement on mcpServers\n- update role docs, inventory defaults, AGENTS guidance, and role test assertions\n\n## Notes\n- This branch excludes profile-specific inventory/zzq changes.