### PR TITLE
feat(agent_claude_code): support skipDangerousModePermissionPrompt setting

### DIFF
--- a/inventory/default/group_vars/all/claude_code/settings.yml
+++ b/inventory/default/group_vars/all/claude_code/settings.yml
@@ -67,6 +67,10 @@ claude_code_settings:
   # 聊天记录保留天数（0 = 永不清理）
   cleanupPeriodDays: 60
 
+  # 是否跳过 --dangerously-skip-permissions 模式的二次确认对话
+  # 仅在你确实理解风险并需要无人值守跳过时打开；默认保持 false
+  skipDangerousModePermissionPrompt: false
+
   # ===== Claude 插件配置（来自官方市场） =====
   enabled_plugins: []
     # - "code-review@claude-plugins-official" # 官方 Code Review 插件，提供代码审查和改进建议能力

--- a/roles/agent_claude_code/README.md
+++ b/roles/agent_claude_code/README.md
@@ -69,6 +69,7 @@ agent_claude_code_settings:
     deny: []
   cleanupPeriodDays: 30
   hooks: {}
+  skipDangerousModePermissionPrompt: false
   enabledPlugins:
     - example-plugin@claude-plugins-official
   statusLine:
@@ -145,6 +146,7 @@ agent_claude_code_result:
 - `skills` 不再由本 role 直接同步，建议改用 `managed_agent_skills` role 统一管理。
 - 本 role 不管理 `agents` 目录，也不会主动创建它。
 - Claude Opus 4.7+ 建议使用 `alwaysThinkingEnabled: false` 配合 `effortLevel`，避免触发已废弃的 `thinking.enabled` 请求语义。
+- `skipDangerousModePermissionPrompt: true` 仅在你已充分理解 `--dangerously-skip-permissions` 风险并需要无人值守跳过时启用；默认 `false` 时该字段不会写入 `settings.json`，避免覆盖 Claude CLI 自身的接受状态。
 - `agent_claude_code_plugins_to_install` 为空时，会自动使用 `agent_claude_code_settings.enabledPlugins` 作为插件安装目标。
 - `agent_claude_code_output_styles_src` 会自动归一化为以 `/` 结尾的目录同步语义。
 - `agent_claude_code_confirm_settings_update` 和 `agent_claude_code_confirm_user_json_update` 适用于手动执行 playbook 的交互确认；如果是无人值守执行，应保持为 `false`。

--- a/roles/agent_claude_code/defaults/main.yml
+++ b/roles/agent_claude_code/defaults/main.yml
@@ -93,6 +93,9 @@ agent_claude_code_settings:
     deny: []
   cleanupPeriodDays: 30
   hooks: {}
+  # 是否跳过 --dangerously-skip-permissions 模式的二次确认对话；
+  # 通常由 Claude CLI 自行写入，这里允许声明式管理用于无人值守场景。
+  skipDangerousModePermissionPrompt: false
   enabledPlugins: []
   statusLine:
     type: command

--- a/roles/agent_claude_code/molecule/default/converge.yml
+++ b/roles/agent_claude_code/molecule/default/converge.yml
@@ -104,6 +104,7 @@
             deny: []
           cleanupPeriodDays: 14
           hooks: {}
+          skipDangerousModePermissionPrompt: true
           enabledPlugins:
             - test-plugin@claude-plugins-official
           statusLine:

--- a/roles/agent_claude_code/molecule/default/files/settings.schema.json
+++ b/roles/agent_claude_code/molecule/default/files/settings.schema.json
@@ -68,6 +68,9 @@
     "hooks": {
       "type": "object"
     },
+    "skipDangerousModePermissionPrompt": {
+      "type": "boolean"
+    },
     "statusLine": {
       "type": "object",
       "required": ["type", "command", "padding"],

--- a/roles/agent_claude_code/molecule/default/verify.yml
+++ b/roles/agent_claude_code/molecule/default/verify.yml
@@ -35,6 +35,7 @@
             deny: []
           cleanupPeriodDays: 14
           hooks: {}
+          skipDangerousModePermissionPrompt: true
           enabledPlugins:
             - test-plugin@claude-plugins-official
           statusLine:
@@ -105,6 +106,7 @@
           - (agent_claude_code_settings_json_final.content | b64decode | from_json).env.ANTHROPIC_API_KEY == 'test-key'
           - (agent_claude_code_settings_json_final.content | b64decode | from_json).alwaysThinkingEnabled == false
           - (agent_claude_code_settings_json_final.content | b64decode | from_json).effortLevel == 'high'
+          - (agent_claude_code_settings_json_final.content | b64decode | from_json).skipDangerousModePermissionPrompt == true
           - (agent_claude_code_user_json_final.content | b64decode | from_json).untouched == true
           - (agent_claude_code_user_json_final.content | b64decode | from_json).mcpServers['local-demo'].command == 'node'
           - (agent_claude_code_user_json_final.content | b64decode | from_json).mcpServers.existing.command == 'python3'

--- a/roles/agent_claude_code/tasks/validate.yml
+++ b/roles/agent_claude_code/tasks/validate.yml
@@ -39,6 +39,7 @@
           },
           'cleanupPeriodDays': 30,
           'hooks': {},
+          'skipDangerousModePermissionPrompt': false,
           'enabledPlugins': [],
           'statusLine': {
             'type': 'command',
@@ -69,6 +70,7 @@
       - agent_claude_code_settings_normalized.permissions.deny is sequence
       - agent_claude_code_settings_normalized.permissions.deny is not string
       - agent_claude_code_settings_normalized.hooks is mapping
+      - agent_claude_code_settings_normalized.skipDangerousModePermissionPrompt in [true, false]
       - agent_claude_code_settings_normalized.enabledPlugins is sequence
       - agent_claude_code_settings_normalized.enabledPlugins is not string
       - agent_claude_code_settings_normalized.statusLine is mapping

--- a/roles/agent_claude_code/tasks/verify.yml
+++ b/roles/agent_claude_code/tasks/verify.yml
@@ -65,6 +65,16 @@
     - agent_claude_code_manage_settings | bool
     - agent_claude_code_settings_normalized.effortLevel | length > 0
 
+- name: 验证 settings.json skipDangerousModePermissionPrompt 字段
+  assert:
+    that:
+      - agent_claude_code_settings_data.skipDangerousModePermissionPrompt | default(false) | bool
+        == agent_claude_code_settings_normalized.skipDangerousModePermissionPrompt | bool
+    fail_msg: "settings.json skipDangerousModePermissionPrompt 字段不匹配"
+    success_msg: "✓ settings.json skipDangerousModePermissionPrompt 字段正确"
+  when:
+    - agent_claude_code_manage_settings | bool
+
 - name: 验证 settings.json 启用插件配置
   assert:
     that:

--- a/roles/agent_claude_code/templates/settings.json.j2
+++ b/roles/agent_claude_code/templates/settings.json.j2
@@ -34,4 +34,7 @@
 {% endfor %}
 {% set settings_data = settings_data | combine({'enabledPlugins': ns.enabled_plugins_map}, recursive=True) %}
 {% endif %}
+{% if agent_claude_code_settings_normalized.skipDangerousModePermissionPrompt | bool %}
+{% set settings_data = settings_data | combine({'skipDangerousModePermissionPrompt': true}, recursive=True) %}
+{% endif %}
 {{ settings_data | to_nice_json(sort_keys=True) }}


### PR DESCRIPTION
## 背景

Claude Code 的 [settings.json schema](https://json.schemastore.org/claude-code-settings.json) 包含一个布尔字段 `skipDangerousModePermissionPrompt`，用于记录用户是否已接受 `--dangerously-skip-permissions` 模式的二次确认对话。

> Whether the user has accepted the bypass permissions mode dialog. Typically managed by the CLI rather than set by hand.

虽然这个字段一般由 Claude CLI 自身在用户首次接受对话时写入，但在以下场景里希望能够通过 ansible 声明式地预先接受：

- 远端无人值守 / 镜像批量构建时无法弹出交互对话
- 想把"已接受跳过提示"这一状态固化在 inventory 配置里

当前 `agent_claude_code` 的模板会显式构造 `settings.json` 字段集合，未在白名单里的键会被丢弃，所以即使 inventory 里写了 `skipDangerousModePermissionPrompt: true`，最终生成的 `settings.json` 里也不会出现该字段。

## 改动

让 role 显式支持这个字段，但只在用户主动开启时写入 `settings.json`，避免默认值反向覆盖 CLI 自身已经接受的状态：

| 文件 | 作用 |
|---|---|
| `roles/agent_claude_code/defaults/main.yml` | 在 `agent_claude_code_settings` 默认值里新增 `skipDangerousModePermissionPrompt: false`，并写注释说明语义 |
| `roles/agent_claude_code/tasks/validate.yml` | 把字段纳入归一化字典并断言为布尔类型 |
| `roles/agent_claude_code/templates/settings.json.j2` | **仅当字段为 `true` 时才写入** `settings.json`，避免默认 `false` 反向覆盖 Claude CLI 自身的接受状态 |
| `roles/agent_claude_code/tasks/verify.yml` | 增加字段断言，覆盖"默认 false 时未写入"与"true 时严格写入"两种情况 |
| `roles/agent_claude_code/molecule/default/converge.yml` & `verify.yml` & `files/settings.schema.json` | molecule 默认场景把该字段设为 `true` 并断言；schema 加上 boolean 类型 |
| `inventory/default/group_vars/all/claude_code/settings.yml` | 给默认 profile 加示例（保持 `false` 默认安全态） |
| `roles/agent_claude_code/README.md` | 在示例和说明里描述新字段，强调"默认 false 时不会写入 JSON"的设计 |

## 设计决策

- **默认 `false`，但默认 `false` 时不写入 JSON**：因为 Claude CLI 自身可能已经把这个字段写为 `true`，如果我们每次都用 `false` 覆盖，就会强制用户每次重新点确认。所以"未声明意图"的场景下，我们不动这个字段。
- **`true` 时严格写入**：用户既然显式打开，那就需要保证幂等地落到目标 `settings.json` 中。

## 验证

- 7 个入口 playbook 对 `inventory/default` 都通过 `--syntax-check`。
- 用 `template` 模块本地渲染并断言：
  - `false` 场景：生成的 JSON 中不包含 `skipDangerousModePermissionPrompt` 键。
  - `true` 场景：生成的 JSON 中 `skipDangerousModePermissionPrompt == true`，且 `effortLevel` / `enabledPlugins` / `language` 等既有字段未受影响。
- molecule 默认场景已经更新到 `skipDangerousModePermissionPrompt: true`，并在 `verify.yml` 中加入断言；CI 会跑完整 podman 测试。

## 参考

- [Claude Code settings.json schema](https://json.schemastore.org/claude-code-settings.json)
- [Claude Code settings 文档](https://code.claude.com/docs/en/settings)