### PR TITLE
feat(agent_opencode): add OpenCode support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           uv run ansible-playbook --syntax-check playbooks/setup_gemini_cli.yml
           uv run ansible-playbook --syntax-check playbooks/setup_copilot_cli.yml
           uv run ansible-playbook --syntax-check playbooks/setup_cursor.yml
+          uv run ansible-playbook --syntax-check playbooks/setup_opencode.yml
           uv run ansible-playbook --syntax-check playbooks/setup_opencommit.yml
           uv run ansible-playbook --syntax-check playbooks/setup_agent_skills.yml
 
@@ -47,6 +48,7 @@ jobs:
           - gemini_cli
           - copilot_cli
           - cursor
+          - opencode
           - opencommit
 
     steps:
@@ -75,6 +77,7 @@ jobs:
             gemini_cli)   echo "playbook=playbooks/setup_gemini_cli.yml"    >> "$GITHUB_OUTPUT" ;;
             copilot_cli)  echo "playbook=playbooks/setup_copilot_cli.yml"   >> "$GITHUB_OUTPUT" ;;
             cursor)       echo "playbook=playbooks/setup_cursor.yml"        >> "$GITHUB_OUTPUT" ;;
+            opencode)     echo "playbook=playbooks/setup_opencode.yml"      >> "$GITHUB_OUTPUT" ;;
             opencommit)   echo "playbook=playbooks/setup_opencommit.yml"    >> "$GITHUB_OUTPUT" ;;
           esac
 
@@ -100,6 +103,7 @@ jobs:
           ]
 
           codex_settings = load_yaml("inventory/default/group_vars/all/codex/settings.yml")["codex_settings"]
+          opencode_settings = load_yaml("inventory/default/group_vars/all/opencode/settings.yml")["opencode_settings"]
           opencommit_settings = load_yaml("inventory/default/group_vars/all/opencommit/settings.yml")["opencommit_settings"]
 
           claude_code_verify_schema = True
@@ -120,6 +124,10 @@ jobs:
               "gemini_confirm_settings_update": False,
               "gemini_confirm_env_update": False,
               "gemini_verify_schema": gemini_verify_schema,
+              "opencode_settings": opencode_settings,
+              "opencode_confirm_config_update": False,
+              "opencode_confirm_tui_config_update": False,
+              "opencode_confirm_sensitive_update": False,
               "opencommit_settings": opencommit_settings,
               "opencommit_confirm_config_update": False,
           }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to AI coding agents working in this repository.
 
 ## 项目快照
 
-这是一个基于 Ansible 的 AI Agent / AI CLI 配置管理仓库，目标是把 Claude Code、Codex CLI、Gemini CLI、GitHub Copilot CLI、Cursor、OpenCommit 以及 agent skills 以声明式方式同步到本地或远端主机。
+这是一个基于 Ansible 的 AI Agent / AI CLI 配置管理仓库，目标是把 Claude Code、Codex CLI、Gemini CLI、GitHub Copilot CLI、Cursor、OpenCode、OpenCommit 以及 agent skills 以声明式方式同步到本地或远端主机。
 
 仓库根目录的 `AGENTS.md` 用于约束你在这个代码仓库里的工作方式；`inventory/<profile>/codex_assets/AGENTS.md` 和 `inventory/<profile>/gemini_assets/GEMINI.md` 则是样例资产，会被同步到目标机的用户级指令文件，两者不要混淆。
 
@@ -21,12 +21,14 @@ uv run ansible-playbook playbooks/setup_codex.yml
 uv run ansible-playbook playbooks/setup_gemini_cli.yml
 uv run ansible-playbook playbooks/setup_copilot_cli.yml
 uv run ansible-playbook playbooks/setup_cursor.yml
+uv run ansible-playbook playbooks/setup_opencode.yml
 uv run ansible-playbook playbooks/setup_opencommit.yml
 uv run ansible-playbook playbooks/setup_agent_skills.yml
 
 # 显式指定 profile 运行
 scripts/run-playbook.sh <profile> playbooks/setup_codex.yml
 scripts/run-playbook.sh <profile> playbooks/setup_cursor.yml -e "target_hosts=all"
+scripts/run-playbook.sh <profile> playbooks/setup_opencode.yml
 scripts/run-playbook.sh <profile> playbooks/setup_opencommit.yml
 
 # 面向 inventory 中全部主机执行
@@ -35,6 +37,7 @@ uv run ansible-playbook playbooks/setup_codex.yml -e "target_hosts=all"
 uv run ansible-playbook playbooks/setup_gemini_cli.yml -e "target_hosts=all"
 uv run ansible-playbook playbooks/setup_copilot_cli.yml -e "target_hosts=all"
 uv run ansible-playbook playbooks/setup_cursor.yml -e "target_hosts=all"
+uv run ansible-playbook playbooks/setup_opencode.yml -e "target_hosts=all"
 uv run ansible-playbook playbooks/setup_opencommit.yml -e "target_hosts=all"
 uv run ansible-playbook playbooks/setup_agent_skills.yml -e "target_hosts=all"
 
@@ -78,6 +81,11 @@ agent_cursor
   ├── npm_command_bootstrap
   └── managed_json_merge
 
+agent_opencode
+  ├── npm_command_bootstrap
+  ├── managed_file
+  └── managed_tree
+
 managed_agent_skills
   └── npm_command_bootstrap
 ```
@@ -90,6 +98,7 @@ managed_agent_skills
 - `opencommit_cli`：检查 OpenCommit CLI，生成 `~/.opencommit`。
 - `agent_copilot_cli`：检查 Copilot CLI，生成并验证 `~/.copilot/mcp-config.json`。
 - `agent_cursor`：检查 Cursor Agent CLI（`agent`），生成并验证 `~/.cursor/mcp.json`。
+- `agent_opencode`：检查 OpenCode CLI，生成 `~/.config/opencode/opencode.json` 和可选 `tui.json`，同步受管密钥文件、可选认证文件与资产目录。
 - `managed_agent_skills`：基于 `skills` CLI 声明式安装或卸载 skills。
 
 ### 基础能力 role
@@ -106,13 +115,14 @@ playbooks/                     # 顶层入口
 roles/                         # 所有 Ansible roles
 inventory/default/             # 默认 inventory 示例
 inventory/default/group_vars/all/
-  ├── agent_mcps/              # Claude / Codex / Copilot / Cursor 共享 MCP 默认值
+  ├── agent_mcps/              # Claude / Codex / Copilot / Cursor / OpenCode 共享 MCP 默认值
   ├── agent_skills/            # skills CLI 与条目声明
   ├── claude_code/             # Claude Code 设置、模型、MCP 覆盖
   ├── codex/                   # Codex 设置、模型、MCP 覆盖
   ├── gemini_cli/              # Gemini CLI 设置、模型、MCP 覆盖
   ├── copilot_cli/             # Copilot CLI 设置、MCP 覆盖
   ├── cursor/                  # Cursor 设置、MCP 覆盖
+  ├── opencode/                # OpenCode 设置、模型、MCP 覆盖
   ├── opencommit/              # OpenCommit 设置与模型覆盖
   └── secrets.yml              # inventory 级敏感信息
 inventory/default/claude_assets/
@@ -158,8 +168,9 @@ tmps/                          # 本地执行时的默认备份和日志目录
 ### 4. 共享 MCP 与 agent 覆盖要分层维护
 
 - 共享默认值维护在 `group_vars/all/agent_mcps/servers.yml` 的 `agent_mcps` 下。
-- Claude、Codex、Gemini、Copilot、Cursor 的差异化覆盖分别放在各自 `mcp_servers.yml`。
-- Claude Code 需要 `mcpServers` 结构，Codex 需要 `mcp_servers`，Gemini CLI 需要 `mcpServers`，Copilot CLI 需要 `mcpServers` 且每个条目带 `tools`，Cursor 需要 `mcpServers`；这些转换发生在对应 playbook 的 `pre_tasks`。
+- Claude、Codex、Gemini、Copilot、Cursor、OpenCode 的差异化覆盖分别放在各自 `mcp_servers.yml`。
+- Claude Code 需要 `mcpServers` 结构，Codex 需要 `mcp_servers`，Gemini CLI 需要 `mcpServers`，Copilot CLI 需要 `mcpServers` 且每个条目带 `tools`，Cursor 需要 `mcpServers`，OpenCode 需要 `mcp`；这些转换发生在对应 playbook 的 `pre_tasks`。
+- OpenCode 本地 MCP 使用 `type: local` 和数组形式 `command`，远端 MCP 使用 `type: remote` 与 `url`。
 
 ### 5. include_role 传路径时先固化 `role_path`
 
@@ -177,12 +188,13 @@ tmps/                          # 本地执行时的默认备份和日志目录
 - `setup_opencommit.yml` 会把 `opencommit/settings.yml` 与 `models.yml` 归一化成单个 `opencommit_cli_config` 输入，并同步到 `~/.opencommit`。
 - `setup_copilot_cli.yml` 当前只管理 `~/.copilot/mcp-config.json`，不负责 Copilot CLI 账号、模型或其他偏好设置。
 - `setup_cursor.yml` 当前只管理 `~/.cursor/mcp.json`，供 Cursor 编辑器与 Cursor Agent CLI 共享使用，不负责账号、模型或其他偏好设置。
+- `setup_opencode.yml` 会把 `opencode/settings.yml`、`models.yml`、`agent_mcps/servers.yml` 和 `opencode/mcp_servers.yml` 归一化成单个 `agent_opencode_config` 输入，并可写入 `~/.local/share/opencode/managed-secrets/` 中的密钥文件；`auth.json` / `mcp-auth.json` 支持但默认不管理。
 - `managed_agent_skills` 的 `source` 必须对目标机可见；仓库内路径通常只适用于 `ansible_connection=local`。
 - `ansible.cfg` 中启用了 `any_errors_fatal = True` 和 `gathering = explicit`，所以失败会立刻终止，facts 也不会默认收集。
 
 ## CI 与升级细节
 
-- `.github/workflows/ci.yml` 会在每次 `push` 时触发，先对 7 个入口 playbook 做 `--syntax-check`，再用 matrix 分别执行 `claude_code`、`codex`、`gemini_cli`、`copilot_cli`、`cursor`、`opencommit`，并在每个矩阵实例后执行 `setup_agent_skills.yml`。
+- `.github/workflows/ci.yml` 会在每次 `push` 时触发，先对 8 个入口 playbook 做 `--syntax-check`，再用 matrix 分别执行 `claude_code`、`codex`、`gemini_cli`、`copilot_cli`、`cursor`、`opencode`、`opencommit`，并在每个矩阵实例后执行 `setup_agent_skills.yml`。
 - CI 当前固定使用 `inventory/default/inventory.yml` 的 localhost 配置，不会自动切换到其他 profile。
 - 当前 CI 依赖的 Repository Secrets 只有 `VOLCES_API_KEY` 和 `PPIO_API_KEY`。
 - CI 会通过 extra vars 显式设置这些确认项为 `false` 以实现无人值守：
@@ -190,6 +202,9 @@ tmps/                          # 本地执行时的默认备份和日志目录
   - `claude_code_confirm_user_json_update`
   - `copilot_cli_confirm_mcp_config_update`
   - `cursor_confirm_mcp_config_update`
+  - `opencode_confirm_config_update`
+  - `opencode_confirm_tui_config_update`
+  - `opencode_confirm_sensitive_update`
   - `codex_confirm_config_update`
   - `codex_confirm_env_update`
   - `gemini_confirm_settings_update`
@@ -219,6 +234,7 @@ tmps/                          # 本地执行时的默认备份和日志目录
 - `agent_codex` 的验证依赖目标端 Python 内置 `tomllib`，目标主机需要 Python `>=3.11`。
 - `agent_gemini_cli` 的验证依赖目标端 Python 内置 `json`，默认用户级输出包括 `~/.gemini/settings.json`、`~/.gemini/.env` 和 `~/GEMINI.md`。
 - `opencommit_cli` 的验证依赖目标端 Python 内置 `json`，默认用户级输出为 `~/.opencommit`。
+- `agent_opencode` 的验证依赖目标端 Python 内置 `json`，默认用户级输出包括 `~/.config/opencode/opencode.json`、可选 `~/.config/opencode/tui.json` 和 `~/.local/share/opencode/managed-secrets/*`。
 
 如果你修改了某个 role，优先在对应 role 目录下运行相关 Molecule 场景，而不是只做静态阅读。
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # agent-config-ansible
 
-基于 Ansible 的 AI Agent / AI CLI 配置管理仓库，用来把 Claude Code、Codex CLI、Gemini CLI、GitHub Copilot CLI、Cursor、OpenCommit 以及 agent skills 以声明式方式同步到本地或远端主机。
+基于 Ansible 的 AI Agent / AI CLI 配置管理仓库，用来把 Claude Code、Codex CLI、Gemini CLI、GitHub Copilot CLI、Cursor、OpenCode、OpenCommit 以及 agent skills 以声明式方式同步到本地或远端主机。
 
 ## 管理范围
 
@@ -11,6 +11,7 @@
 | `playbooks/setup_gemini_cli.yml`   | 部署 Gemini CLI 的 `settings.json`、`.env` 与可选 `GEMINI.md` |
 | `playbooks/setup_copilot_cli.yml`  | 部署 GitHub Copilot CLI 的 `~/.copilot/mcp-config.json`       |
 | `playbooks/setup_cursor.yml`       | 部署 Cursor / Cursor Agent CLI 共用的 `~/.cursor/mcp.json`    |
+| `playbooks/setup_opencode.yml`     | 部署 OpenCode 的 `opencode.json`、可选 `tui.json`、敏感文件与资产目录 |
 | `playbooks/setup_opencommit.yml`   | 部署 OpenCommit CLI 的 `~/.opencommit`                        |
 | `playbooks/setup_agent_skills.yml` | 通过 `skills` CLI 声明式安装或卸载 skills                     |
 
@@ -61,6 +62,7 @@ inventory/<profile>/
 │   ├── gemini_cli/
 │   ├── copilot_cli/
 │   ├── cursor/
+│   ├── opencode/
 │   ├── opencommit/
 │   └── secrets.yml
 ├── claude_assets/
@@ -74,6 +76,7 @@ inventory/<profile>/
 - 共享 MCP 默认值放在 `group_vars/all/agent_mcps/servers.yml`。
 - 某个工具的差异化配置放在对应目录下的 `mcp_servers.yml`。
 - API Key、token 等敏感信息放在 `group_vars/all/secrets.yml` 或 CI Secret，不要写进说明资产。
+- OpenCode 默认通过 `~/.local/share/opencode/managed-secrets/` 中的受管密钥文件和 `{file:...}` 引用使用 API key；`auth.json` / `mcp-auth.json` 支持声明式管理，但默认关闭。
 - `confirm`、备份目录、CLI 检查、自动安装、`manage_*`、`run_verify` 这类运行控制默认已内置，只有需要覆盖时再显式声明。
 - Codex CLI 会把本地信任目录写进 `~/.codex/config.toml` 的 `[projects]` 段；`setup_codex.yml` 会保留目标机现有的本地 `projects` 状态，避免这些路径造成声明式配置漂移，因此无需把它们写进 inventory。
 
@@ -89,6 +92,7 @@ uv run ansible-playbook playbooks/setup_codex.yml
 uv run ansible-playbook playbooks/setup_gemini_cli.yml
 uv run ansible-playbook playbooks/setup_copilot_cli.yml
 uv run ansible-playbook playbooks/setup_cursor.yml
+uv run ansible-playbook playbooks/setup_opencode.yml
 uv run ansible-playbook playbooks/setup_opencommit.yml
 uv run ansible-playbook playbooks/setup_agent_skills.yml
 ```
@@ -122,6 +126,7 @@ scripts/run-playbook.sh personal playbooks/setup_cursor.yml -e "target_hosts=all
 
 ```bash
 uv run ansible-playbook --syntax-check playbooks/setup_codex.yml
+uv run ansible-playbook --syntax-check playbooks/setup_opencode.yml
 
 cd roles/agent_codex
 uv run molecule test

--- a/inventory/default/group_vars/all/agent_mcps/servers.yml
+++ b/inventory/default/group_vars/all/agent_mcps/servers.yml
@@ -1,5 +1,5 @@
 # Agent 通用 MCP 服务器配置
-# 这里维护 Claude Code / Codex CLI / Gemini CLI / GitHub Copilot CLI / Cursor 共用的默认 MCP 定义。
+# 这里维护 Claude Code / Codex CLI / Gemini CLI / GitHub Copilot CLI / Cursor / OpenCode 共用的默认 MCP 定义。
 #
 # 覆盖规则：
 # - Claude Code 可在 group_vars/all/claude_code/mcp_servers.yml 的
@@ -12,10 +12,12 @@
 #   copilot_cli_mcp_servers 下按同名服务覆盖或补充。
 # - Cursor 可在 group_vars/all/cursor/mcp_servers.yml 的 cursor_mcp_servers 下
 #   按同名服务覆盖或补充。
+# - OpenCode 可在 group_vars/all/opencode/mcp_servers.yml 的 opencode_mcp_servers 下
+#   按同名服务覆盖或补充。
 #
 # 统一结构使用显式 type 字段：
 #   stdio: command + args (+ env 可选)
-#   http:  url (+ headers / bearer_token_env_var 可选)
+#   http/remote:  url (+ headers / bearer_token_env_var 可选)
 
 agent_mcps:
   # 用于自动获取网络内容，并转换成 Markdown 格式给 Agent

--- a/inventory/default/group_vars/all/opencode/mcp_servers.yml
+++ b/inventory/default/group_vars/all/opencode/mcp_servers.yml
@@ -1,0 +1,12 @@
+# OpenCode MCP 覆盖配置
+# 默认共享 MCP 定义统一维护在 group_vars/all/agent_mcps/servers.yml 的 agent_mcps 下。
+# 这里仅放 OpenCode 特有的覆盖项；会在渲染 ~/.config/opencode/opencode.json 前与共享配置递归合并。
+
+opencode_mcp_servers:
+  context7:
+    type: "stdio"
+    command: "npx"
+    args: ["-y", "@upstash/context7-mcp"]
+  deepwiki:
+    type: "http"
+    url: "https://mcp.deepwiki.com/mcp"

--- a/inventory/default/group_vars/all/opencode/models.yml
+++ b/inventory/default/group_vars/all/opencode/models.yml
@@ -1,0 +1,23 @@
+# OpenCode 模型配置
+# config 会合并到 ~/.config/opencode/opencode.json
+# secret_files 会写入 ~/.local/share/opencode/managed-secrets/
+
+opencode_model_configs:
+  ppio_gpt5_4:
+    config:
+      model: "ppio/pa/gpt-5.4"
+      small_model: "ppio/pa/gpt-5.4"
+      provider:
+        ppio:
+          npm: "@ai-sdk/openai"
+          name: "PPIO (GPT-5.4)"
+          options:
+            baseURL: "https://api.ppio.com/openai/v1"
+            apiKey: "{file:~/.local/share/opencode/managed-secrets/ppio-api-key}"
+          models:
+            "pa/gpt-5.4":
+              name: "PPIO GPT-5.4"
+    secret_files:
+      ppio-api-key: "{{ (secrets | default({})).get('api_keys', {}).get('ppio', '') }}"
+
+opencode_use_model: ppio_gpt5_4

--- a/inventory/default/group_vars/all/opencode/settings.yml
+++ b/inventory/default/group_vars/all/opencode/settings.yml
@@ -1,0 +1,34 @@
+# OpenCode 相关设置
+# 这些设置会被转换成 ~/.config/opencode/opencode.json 的内容。
+# 详细配置项说明请参考官方文档：https://opencode.ai/docs/config/
+# 交互确认、备份目录、CLI 检查、自动安装、manage/run_verify 等运行控制默认已内置；
+# 只有需要覆盖时，才在 profile 中额外声明对应顶层变量。
+
+opencode_settings:
+  "$schema": "https://opencode.ai/config.json"
+
+  # OpenCode 用 npm / Homebrew 等包管理器安装时，官方 autoupdate 不生效；
+  # 这里显式关闭，避免 CLI 自行更新造成托管漂移。
+  autoupdate: false
+
+  # OpenCode 默认允许所有操作；示例默认要求编辑与 shell 命令确认。
+  permission:
+    edit: ask
+    bash: ask
+
+  provider: {}
+  mcp: {}
+
+# OpenCode TUI 配置；为空时默认不写 ~/.config/opencode/tui.json。
+opencode_tui_settings: {}
+
+# 额外写入 ~/.local/share/opencode/managed-secrets/ 的敏感文件。
+# 值可以是字符串，也可以是 {content, path, mode}。
+opencode_secret_files: {}
+
+# 可选认证文件，默认不管理；通常优先使用 OpenCode 的 /connect 或 {env:...}/{file:...}。
+opencode_auth: {}
+opencode_mcp_auth: {}
+
+# 可选资产目录，key 支持 agents/commands/modes/plugins/skills/tools/themes。
+opencode_asset_dirs: {}

--- a/playbooks/setup_opencode.yml
+++ b/playbooks/setup_opencode.yml
@@ -1,0 +1,372 @@
+---
+# playbooks/setup_opencode.yml
+# OpenCode 配置部署（基于本仓库 roles/agent_opencode）
+#
+# 功能：
+# 0. 递归加载 inventory/<profile>/group_vars/all 下的所有 yml/yaml 变量片段
+# 1. 将当前仓库的 opencode_* 变量桥接为 agent_opencode 所需的输入
+# 2. 将共享 agent_mcps 与 OpenCode 覆盖项归一化为 OpenCode 的 mcp 结构
+# 3. 执行 agent_opencode role，完成 opencode.json、tui.json、敏感文件与可选资产目录同步
+#
+# 使用方法：
+#   uv run ansible-playbook -i inventory/default/inventory.yml playbooks/setup_opencode.yml
+#   uv run ansible-playbook -i inventory/default/inventory.yml playbooks/setup_opencode.yml -e "target_hosts=all"
+#
+# 默认变量目录：
+#   inventory/<profile>/group_vars/all/opencode/
+#     - settings.yml
+#     - models.yml
+#     - mcp_servers.yml
+#
+# 默认备份目录（本地连接时）：
+#   <repo>/tmps/opencode-backups/<inventory_hostname>/
+#     - config/
+#     - tui/
+#     - sensitive/
+
+- name: OpenCode 配置部署
+  hosts: "{{ target_hosts | default('localhost') }}"
+  gather_facts: false
+
+  pre_tasks:
+    - name: 递归加载 group_vars/all 变量文件
+      include_vars:
+        dir: "{{ inventory_dir }}/group_vars/all"
+        extensions:
+          - yml
+          - yaml
+        ignore_unknown_extensions: true
+      tags:
+        - always
+
+    - name: 计算 OpenCode 备份根目录
+      set_fact:
+        opencode_backup_root_effective: >-
+          {{
+            opencode_backup_root
+            if (opencode_backup_root is defined)
+            else (
+              (((inventory_dir | dirname) | dirname) ~ '/tmps/opencode-backups/' ~ inventory_hostname)
+              if ((ansible_connection | default('ssh')) == 'local')
+              else ''
+            )
+          }}
+      tags:
+        - always
+
+    - name: 校验 OpenCode 编排输入
+      assert:
+        that:
+          - opencode_settings is mapping
+          - opencode_model_configs is mapping
+          - opencode_use_model is string
+          - opencode_use_model | length > 0
+          - opencode_use_model in opencode_model_configs
+          - (agent_mcps | default({})) is mapping
+          - (opencode_mcp_servers | default({})) is mapping
+          - (opencode_tui_settings | default({})) is mapping
+          - (opencode_secret_files | default({})) is mapping
+          - (opencode_auth | default({})) is mapping
+          - (opencode_mcp_auth | default({})) is mapping
+          - (opencode_asset_dirs | default({})) is mapping
+          - (opencode_model_configs[opencode_use_model].config | default({})) is mapping
+          - (opencode_model_configs[opencode_use_model].secret_files | default({})) is mapping
+        fail_msg: >-
+          OpenCode 编排输入无效：请检查 opencode/settings.yml、models.yml、
+          agent_mcps/servers.yml、opencode/mcp_servers.yml 中的变量结构，
+          尤其是 opencode_use_model、config、secret_files 与 mcp。
+      tags:
+        - always
+
+    - name: 初始化 OpenCode MCP 配置
+      set_fact:
+        opencode_mcp_servers_effective: {}
+      tags:
+        - always
+
+    - name: 校验 OpenCode MCP 条目
+      assert:
+        that:
+          - item.value is mapping
+          - opencode_server_type in ['local', 'stdio', 'http', 'sse', 'remote']
+          - (item.value.args is not defined) or ((item.value.args is sequence) and (item.value.args is not string))
+          - (item.value.cwd is not defined) or (item.value.cwd is string)
+          - (item.value.env is not defined) or (item.value.env is mapping)
+          - (item.value.environment is not defined) or (item.value.environment is mapping)
+          - (item.value.headers is not defined) or (item.value.headers is mapping)
+          - (item.value.enabled is not defined) or (item.value.enabled is boolean)
+          - (item.value.oauth is not defined) or (item.value.oauth is boolean) or (item.value.oauth is mapping)
+          - >-
+            (
+              (opencode_server_type in ['local', 'stdio'])
+              and (item.value.command | default('') is string)
+              and ((item.value.command | default('')) | length > 0)
+            )
+            or
+            (
+              (opencode_server_type in ['http', 'sse', 'remote'])
+              and (item.value.url | default('') is string)
+              and ((item.value.url | default('')) | length > 0)
+            )
+        fail_msg: >-
+          OpenCode MCP 条目 {{ item.key }} 无效：
+          local/stdio 需要 command（args/cwd/env/environment 可选），
+          http/sse/remote 需要 url；headers/environment/env 必须是对象。
+      vars:
+        opencode_server_type: "{{ item.value.type | default('stdio') | lower }}"
+      loop: >-
+        {{
+          (
+            (agent_mcps | default({}))
+            | combine(opencode_mcp_servers | default({}), recursive=True)
+          )
+          | dict2items
+        }}
+      loop_control:
+        label: "{{ item.key }}"
+      tags:
+        - always
+
+    - name: 归一化 OpenCode MCP 配置
+      set_fact:
+        opencode_mcp_servers_effective: >-
+          {{
+            opencode_mcp_servers_effective
+            | combine(
+                {
+                  item.key: opencode_server_effective
+                },
+                recursive=True
+              )
+          }}
+      vars:
+        opencode_server_type: "{{ item.value.type | default('stdio') | lower }}"
+        opencode_local_env: >-
+          {{
+            (
+              item.value.environment | default({})
+            )
+            | combine(
+                (
+                  item.value.env | default({})
+                  | dict2items
+                  | rejectattr('value', 'equalto', '')
+                  | items2dict
+                ),
+                recursive=True
+              )
+          }}
+        opencode_timeout_effective: >-
+          {{
+            item.value.timeout
+            if (item.value.timeout is defined)
+            else (
+              (item.value.startup_timeout_sec | int) * 1000
+              if (item.value.startup_timeout_sec is defined)
+              else none
+            )
+          }}
+        opencode_local_payload: >-
+          {{
+            item.value
+            | dict2items
+            | rejectattr('key', 'equalto', 'type')
+            | rejectattr('key', 'equalto', 'command')
+            | rejectattr('key', 'equalto', 'args')
+            | rejectattr('key', 'equalto', 'env')
+            | rejectattr('key', 'equalto', 'environment')
+            | rejectattr('key', 'equalto', 'headers')
+            | rejectattr('key', 'equalto', 'url')
+            | rejectattr('key', 'equalto', 'oauth')
+            | rejectattr('key', 'equalto', 'bearer_token_env_var')
+            | rejectattr('key', 'equalto', 'startup_timeout_sec')
+            | rejectattr('key', 'equalto', 'timeout')
+            | items2dict
+          }}
+        opencode_remote_payload: >-
+          {{
+            item.value
+            | dict2items
+            | rejectattr('key', 'equalto', 'type')
+            | rejectattr('key', 'equalto', 'command')
+            | rejectattr('key', 'equalto', 'args')
+            | rejectattr('key', 'equalto', 'env')
+            | rejectattr('key', 'equalto', 'environment')
+            | rejectattr('key', 'equalto', 'bearer_token_env_var')
+            | rejectattr('key', 'equalto', 'startup_timeout_sec')
+            | rejectattr('key', 'equalto', 'timeout')
+            | rejectattr('key', 'equalto', 'headers')
+            | items2dict
+          }}
+        opencode_remote_headers: >-
+          {{
+            (
+              (
+                {'Authorization': 'Bearer {env:' ~ item.value.bearer_token_env_var ~ '}'}
+                if ((item.value.bearer_token_env_var | default('')) | length > 0)
+                else {}
+              )
+              | combine(item.value.headers | default({}), recursive=True)
+            )
+          }}
+        opencode_timeout_payload: >-
+          {{
+            {'timeout': opencode_timeout_effective}
+            if (opencode_timeout_effective is not none)
+            else {}
+          }}
+        opencode_server_effective: >-
+          {{
+            (
+              {
+                'type': 'local',
+                'command': [item.value.command] + (item.value.args | default([]))
+              }
+              | combine(opencode_local_payload, recursive=True)
+              | combine(
+                  (opencode_local_env | length > 0)
+                  | ternary({'environment': opencode_local_env}, {}),
+                  recursive=True
+                )
+              | combine(opencode_timeout_payload, recursive=True)
+            )
+            if opencode_server_type in ['local', 'stdio']
+            else
+            (
+              {
+                'type': 'remote'
+              }
+              | combine(opencode_remote_payload, recursive=True)
+              | combine(
+                  (opencode_remote_headers | length > 0)
+                  | ternary({'headers': opencode_remote_headers}, {}),
+                  recursive=True
+                )
+              | combine(opencode_timeout_payload, recursive=True)
+            )
+          }}
+      loop: >-
+        {{
+          (
+            (agent_mcps | default({}))
+            | combine(opencode_mcp_servers | default({}), recursive=True)
+          )
+          | dict2items
+        }}
+      loop_control:
+        label: "{{ item.key }}"
+      tags:
+        - always
+
+    - name: 归一化 agent_opencode 输入变量
+      set_fact:
+        opencode_settings_effective: >-
+          {{
+            {
+              '$schema': 'https://opencode.ai/config.json',
+              'provider': {},
+              'mcp': {}
+            } | combine(opencode_settings, recursive=True)
+          }}
+        opencode_active_model_config_effective: "{{ opencode_model_configs[opencode_use_model] }}"
+        opencode_confirm_config_update_effective: "{{ opencode_confirm_config_update | default(true) }}"
+        opencode_confirm_tui_config_update_effective: "{{ opencode_confirm_tui_config_update | default(true) }}"
+        opencode_confirm_sensitive_update_effective: "{{ opencode_confirm_sensitive_update | default(true) }}"
+      tags:
+        - always
+
+    - name: 归一化派生 OpenCode 配置变量
+      set_fact:
+        opencode_config_effective: >-
+          {%- set _model_config = opencode_active_model_config_effective.config | default({}) -%}
+          {%- set _merged = opencode_settings_effective | combine(_model_config, recursive=True) -%}
+          {{
+            _merged
+            | combine(
+                {
+                  'provider': (
+                    opencode_settings_effective.provider | default({})
+                  ) | combine(
+                    _model_config.provider | default({}),
+                    recursive=True
+                  ),
+                  'mcp': (
+                    opencode_settings_effective.mcp | default({})
+                  ) | combine(
+                    _model_config.mcp | default({}),
+                    recursive=True
+                  ) | combine(
+                    opencode_mcp_servers_effective,
+                    recursive=True
+                  )
+                },
+                recursive=True
+              )
+          }}
+        opencode_secret_files_effective: >-
+          {{
+            (opencode_active_model_config_effective.secret_files | default({}))
+            | combine(opencode_secret_files | default({}), recursive=True)
+          }}
+      tags:
+        - always
+
+  tasks:
+    - name: 执行 agent_opencode 角色
+      include_role:
+        name: agent_opencode
+      vars:
+        agent_opencode_config_dir: "{{ opencode_config_dir | default(lookup('env', 'HOME') ~ '/.config/opencode') }}"
+        agent_opencode_data_dir: "{{ opencode_data_dir | default(lookup('env', 'HOME') ~ '/.local/share/opencode') }}"
+        agent_opencode_config_path: >-
+          {{
+            opencode_config_path
+            | default((opencode_config_dir | default(lookup('env', 'HOME') ~ '/.config/opencode')) ~ '/opencode.json')
+          }}
+        agent_opencode_tui_config_path: >-
+          {{
+            opencode_tui_config_path
+            | default((opencode_config_dir | default(lookup('env', 'HOME') ~ '/.config/opencode')) ~ '/tui.json')
+          }}
+        agent_opencode_auth_path: >-
+          {{
+            opencode_auth_path
+            | default((opencode_data_dir | default(lookup('env', 'HOME') ~ '/.local/share/opencode')) ~ '/auth.json')
+          }}
+        agent_opencode_mcp_auth_path: >-
+          {{
+            opencode_mcp_auth_path
+            | default((opencode_data_dir | default(lookup('env', 'HOME') ~ '/.local/share/opencode')) ~ '/mcp-auth.json')
+          }}
+        agent_opencode_secret_dir: >-
+          {{
+            opencode_secret_dir
+            | default((opencode_data_dir | default(lookup('env', 'HOME') ~ '/.local/share/opencode')) ~ '/managed-secrets')
+          }}
+        agent_opencode_temp_root: "{{ opencode_temp_root | default('/tmp/agent-opencode') }}"
+        agent_opencode_require_opencode_cli: "{{ opencode_require_opencode_cli | default(true) | bool }}"
+        agent_opencode_opencode_auto_install_npm: "{{ opencode_auto_install_npm | default('opencode-ai') }}"
+        agent_opencode_manage_config: "{{ opencode_manage_config | default(true) | bool }}"
+        agent_opencode_manage_tui_config: "{{ opencode_manage_tui_config | default(opencode_tui_settings | default({}) | length > 0) | bool }}"
+        agent_opencode_manage_secret_files: "{{ opencode_manage_secret_files | default(opencode_secret_files_effective | length > 0) | bool }}"
+        agent_opencode_manage_auth: "{{ opencode_manage_auth | default(false) | bool }}"
+        agent_opencode_manage_mcp_auth: "{{ opencode_manage_mcp_auth | default(false) | bool }}"
+        agent_opencode_manage_assets: "{{ opencode_manage_assets | default(opencode_asset_dirs | default({}) | length > 0) | bool }}"
+        agent_opencode_run_verify: "{{ opencode_run_verify | default(true) | bool }}"
+        agent_opencode_verify_schema: "{{ opencode_verify_schema | default(false) | bool }}"
+        agent_opencode_config_schemafile: "{{ opencode_config_schemafile | default('https://opencode.ai/config.json') }}"
+        agent_opencode_tui_schemafile: "{{ opencode_tui_schemafile | default('https://opencode.ai/tui.json') }}"
+        agent_opencode_confirm_config_update: "{{ opencode_confirm_config_update_effective | bool }}"
+        agent_opencode_confirm_tui_config_update: "{{ opencode_confirm_tui_config_update_effective | bool }}"
+        agent_opencode_confirm_sensitive_update: "{{ opencode_confirm_sensitive_update_effective | bool }}"
+        agent_opencode_backup: "{{ opencode_backup | default(true) | bool }}"
+        agent_opencode_backup_root: "{{ opencode_backup_root_effective }}"
+        agent_opencode_config: "{{ opencode_config_effective }}"
+        agent_opencode_tui_config: "{{ opencode_tui_settings | default({}) }}"
+        agent_opencode_secret_files: "{{ opencode_secret_files_effective }}"
+        agent_opencode_auth: "{{ opencode_auth | default({}) }}"
+        agent_opencode_mcp_auth: "{{ opencode_mcp_auth | default({}) }}"
+        agent_opencode_asset_dirs: "{{ opencode_asset_dirs | default({}) }}"
+        agent_opencode_asset_delete: "{{ opencode_asset_delete | default(true) | bool }}"
+      tags:
+        - always

--- a/roles/agent_opencode/README.md
+++ b/roles/agent_opencode/README.md
@@ -1,0 +1,20 @@
+# agent_opencode
+
+声明式管理 OpenCode 用户级配置。
+
+## 管理内容
+
+- 检查 `opencode` CLI，并可通过 npm 包 `opencode-ai` 自动安装。
+- 渲染 `~/.config/opencode/opencode.json`。
+- 可选渲染 `~/.config/opencode/tui.json`。
+- 可选同步 `~/.local/share/opencode/managed-secrets/*`、`auth.json`、`mcp-auth.json`。
+- 可选同步 OpenCode 资产目录：`agents/`、`commands/`、`modes/`、`plugins/`、`skills/`、`tools/`、`themes/`。
+
+敏感文件不通过 `managed_file` 输出 diff，任务使用 `no_log` 并以 `0600` 权限写入。
+
+## 常用验证
+
+```bash
+cd roles/agent_opencode
+uv run molecule test
+```

--- a/roles/agent_opencode/defaults/main.yml
+++ b/roles/agent_opencode/defaults/main.yml
@@ -1,0 +1,98 @@
+---
+# OpenCode 配置目录
+agent_opencode_config_dir: "{{ lookup('env', 'HOME') }}/.config/opencode"
+
+# OpenCode 数据目录；auth.json 与 mcp-auth.json 默认由 OpenCode 写在这里
+agent_opencode_data_dir: "{{ lookup('env', 'HOME') }}/.local/share/opencode"
+
+# OpenCode 核心文件路径
+agent_opencode_config_path: "{{ agent_opencode_config_dir }}/opencode.json"
+agent_opencode_tui_config_path: "{{ agent_opencode_config_dir }}/tui.json"
+agent_opencode_auth_path: "{{ agent_opencode_data_dir }}/auth.json"
+agent_opencode_mcp_auth_path: "{{ agent_opencode_data_dir }}/mcp-auth.json"
+agent_opencode_secret_dir: "{{ agent_opencode_data_dir }}/managed-secrets"
+
+# 角色工作临时目录
+agent_opencode_temp_root: /tmp/agent-opencode
+
+# 是否要求 OpenCode CLI 可用
+agent_opencode_require_opencode_cli: true
+
+# OpenCode CLI 不可用时用于自动安装的 npm 包名；设为空字符串可关闭自动安装
+agent_opencode_opencode_auto_install_npm: opencode-ai
+
+# 是否管理各类配置，以及执行最终验证
+agent_opencode_manage_config: true
+agent_opencode_manage_tui_config: true
+agent_opencode_manage_secret_files: true
+agent_opencode_manage_auth: false
+agent_opencode_manage_mcp_auth: false
+agent_opencode_manage_assets: true
+agent_opencode_run_verify: true
+
+# 是否在 verify 阶段执行 JSON Schema 校验
+agent_opencode_verify_schema: false
+agent_opencode_config_schemafile: https://opencode.ai/config.json
+agent_opencode_tui_schemafile: https://opencode.ai/tui.json
+
+# 是否在变更非敏感配置或敏感文件时交互确认
+agent_opencode_confirm_config_update: false
+agent_opencode_confirm_tui_config_update: false
+agent_opencode_confirm_sensitive_update: false
+
+# 是否为受管文件创建备份
+agent_opencode_backup: true
+
+# 统一备份根目录；为空时回退到各托管文件默认的就地备份目录
+agent_opencode_backup_root: ""
+
+agent_opencode_config_backup_dir: >-
+  {{
+    ((agent_opencode_backup_root | regex_replace('/+$', '')) ~ '/config')
+    if (agent_opencode_backup_root | length > 0)
+    else ((agent_opencode_config_dir | regex_replace('/+$', '')) ~ '/.managed_file_backups')
+  }}
+agent_opencode_config_backup_prefix: opencode.json
+
+agent_opencode_tui_config_backup_dir: >-
+  {{
+    ((agent_opencode_backup_root | regex_replace('/+$', '')) ~ '/tui')
+    if (agent_opencode_backup_root | length > 0)
+    else ((agent_opencode_config_dir | regex_replace('/+$', '')) ~ '/.managed_file_backups')
+  }}
+agent_opencode_tui_config_backup_prefix: tui.json
+
+agent_opencode_sensitive_backup_dir: >-
+  {{
+    ((agent_opencode_backup_root | regex_replace('/+$', '')) ~ '/sensitive')
+    if (agent_opencode_backup_root | length > 0)
+    else ((agent_opencode_data_dir | regex_replace('/+$', '')) ~ '/.managed_file_backups')
+  }}
+
+# OpenCode 主配置
+agent_opencode_config:
+  "$schema": https://opencode.ai/config.json
+  provider: {}
+  mcp: {}
+
+# OpenCode TUI 配置；为空时默认不写 tui.json
+agent_opencode_tui_config: {}
+
+# 受管密钥文件。值可以是字符串，也可以是 {content, path, mode}
+agent_opencode_secret_files: {}
+
+# 可选认证文件；默认不管理
+agent_opencode_auth: {}
+agent_opencode_mcp_auth: {}
+
+# 可选资产目录。key 仅支持 OpenCode 官方复数目录名
+agent_opencode_asset_dirs: {}
+agent_opencode_asset_delete: true
+agent_opencode_allowed_asset_dirs:
+  - agents
+  - commands
+  - modes
+  - plugins
+  - skills
+  - tools
+  - themes

--- a/roles/agent_opencode/meta/main.yml
+++ b/roles/agent_opencode/meta/main.yml
@@ -1,0 +1,8 @@
+---
+galaxy_info:
+  role_name: agent_opencode
+  author: lingua-realm
+  description: Manage OpenCode CLI user configuration
+  license: MIT
+  min_ansible_version: "2.15"
+dependencies: []

--- a/roles/agent_opencode/molecule/default/converge.yml
+++ b/roles/agent_opencode/molecule/default/converge.yml
@@ -1,0 +1,126 @@
+---
+- name: Converge - OpenCode 自动化配置
+  hosts: all
+  environment:
+    PATH: "{{ agent_opencode_fake_bin }}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+  vars:
+    agent_opencode_test_root: /tmp/agent-opencode/default
+    agent_opencode_fake_bin: "{{ agent_opencode_test_root }}/fake-bin"
+    agent_opencode_config_dir_test: "{{ agent_opencode_test_root }}/home/.config/opencode"
+    agent_opencode_data_dir_test: "{{ agent_opencode_test_root }}/home/.local/share/opencode"
+  tasks:
+    - name: 准备测试目录
+      file:
+        path: "{{ item }}"
+        state: directory
+        mode: "0755"
+      loop:
+        - "{{ agent_opencode_test_root }}"
+        - "{{ agent_opencode_fake_bin }}"
+        - "{{ agent_opencode_test_root }}/home"
+        - "{{ agent_opencode_config_dir_test }}"
+        - "{{ agent_opencode_data_dir_test }}"
+        - "{{ agent_opencode_data_dir_test }}/managed-secrets"
+      tags:
+        - molecule-idempotence-notest
+
+    - name: 安装假 opencode 可执行文件
+      copy:
+        src: "{{ playbook_dir }}/files/fake-bin/opencode"
+        dest: "{{ agent_opencode_fake_bin }}/opencode"
+        mode: "0755"
+      tags:
+        - molecule-idempotence-notest
+
+    - name: 预置旧的 opencode.json
+      copy:
+        dest: "{{ agent_opencode_config_dir_test }}/opencode.json"
+        content: |
+          {"model":"legacy/model"}
+        mode: "0644"
+      tags:
+        - molecule-idempotence-notest
+
+    - name: 预置权限错误的 secret file
+      copy:
+        dest: "{{ agent_opencode_data_dir_test }}/managed-secrets/ppio-api-key"
+        content: test-key
+        mode: "0644"
+      tags:
+        - molecule-idempotence-notest
+
+    - name: 执行 agent_opencode 角色
+      include_role:
+        name: agent_opencode
+      vars:
+        agent_opencode_config_dir: "{{ agent_opencode_config_dir_test }}"
+        agent_opencode_data_dir: "{{ agent_opencode_data_dir_test }}"
+        agent_opencode_temp_root: "{{ agent_opencode_test_root }}/tmp"
+        agent_opencode_confirm_config_update: false
+        agent_opencode_confirm_tui_config_update: false
+        agent_opencode_confirm_sensitive_update: false
+        agent_opencode_config:
+          "$schema": https://opencode.ai/config.json
+          model: ppio/pa-gpt-5.4
+          small_model: ppio/pa-gpt-5.4
+          autoupdate: false
+          permission:
+            edit: ask
+            bash: ask
+          provider:
+            ppio:
+              npm: "@ai-sdk/openai"
+              name: PPIO
+              options:
+                baseURL: https://api.ppio.com/openai/v1
+                apiKey: "{file:/tmp/agent-opencode/default/home/.local/share/opencode/managed-secrets/ppio-api-key}"
+              models:
+                pa-gpt-5.4:
+                  name: PPIO GPT-5.4
+          mcp:
+            fetch:
+              type: local
+              command:
+                - uvx
+                - mcp-server-fetch
+              enabled: true
+            websearch:
+              type: local
+              command:
+                - npx
+                - -y
+                - open-websearch@latest
+              environment:
+                MODE: stdio
+              timeout: 20000
+            deepwiki:
+              type: remote
+              url: https://mcp.deepwiki.com/mcp
+              enabled: true
+              headers:
+                Authorization: "Bearer {env:DEEPWIKI_TOKEN}"
+        agent_opencode_tui_config:
+          theme: system
+        agent_opencode_secret_files:
+          ppio-api-key: test-key
+        agent_opencode_asset_dirs:
+          agents: "{{ playbook_dir }}/files/assets/agents"
+          commands: "{{ playbook_dir }}/files/assets/commands"
+
+    - name: 检查 OpenCode 关键产物
+      stat:
+        path: "{{ item }}"
+      loop:
+        - "{{ agent_opencode_config_dir_test }}/opencode.json"
+        - "{{ agent_opencode_config_dir_test }}/tui.json"
+        - "{{ agent_opencode_data_dir_test }}/managed-secrets/ppio-api-key"
+        - "{{ agent_opencode_config_dir_test }}/agents/reviewer.md"
+        - "{{ agent_opencode_config_dir_test }}/commands/hello.md"
+      register: agent_opencode_product_stats
+
+    - name: 断言 OpenCode 关键产物存在
+      assert:
+        that:
+          - agent_opencode_product_stats.results | map(attribute='stat.exists') | min
+        fail_msg: "agent_opencode 尚未生成完整产物"
+        success_msg: "✓ agent_opencode 已生成关键产物"

--- a/roles/agent_opencode/molecule/default/files/assets/agents/reviewer.md
+++ b/roles/agent_opencode/molecule/default/files/assets/agents/reviewer.md
@@ -1,0 +1,3 @@
+# Reviewer
+
+Review changes for correctness and safety.

--- a/roles/agent_opencode/molecule/default/files/assets/commands/hello.md
+++ b/roles/agent_opencode/molecule/default/files/assets/commands/hello.md
@@ -1,0 +1,3 @@
+# Hello
+
+Say hello in Chinese.

--- a/roles/agent_opencode/molecule/default/files/fake-bin/opencode
+++ b/roles/agent_opencode/molecule/default/files/fake-bin/opencode
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if [ "$1" = "--version" ]; then
+  echo "opencode 0.0.0-test"
+  exit 0
+fi
+
+echo "fake opencode"

--- a/roles/agent_opencode/molecule/default/molecule.yml
+++ b/roles/agent_opencode/molecule/default/molecule.yml
@@ -1,0 +1,29 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: podman
+platforms:
+  - name: instance-agent-opencode-default
+    image: "python:3.13-bookworm"
+    pre_build_image: true
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      roles_path: $PWD/../../roles
+      remote_tmp: /tmp/.ansible/tmp
+scenario:
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - cleanup
+    - destroy
+verifier:
+  name: ansible

--- a/roles/agent_opencode/molecule/default/prepare.yml
+++ b/roles/agent_opencode/molecule/default/prepare.yml
@@ -1,0 +1,15 @@
+---
+- name: Prepare
+  hosts: all
+  tasks:
+    - name: 检查 python3 可用性
+      command: python3 --version
+      changed_when: false
+
+    - name: 检查 diff 可用性
+      command: diff --version
+      changed_when: false
+
+    - name: 检查 tar 可用性
+      command: tar --version
+      changed_when: false

--- a/roles/agent_opencode/molecule/default/verify.yml
+++ b/roles/agent_opencode/molecule/default/verify.yml
@@ -1,0 +1,120 @@
+---
+- name: Verify - OpenCode 自动化配置幂等
+  hosts: all
+  environment:
+    PATH: "{{ agent_opencode_fake_bin }}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+  vars:
+    agent_opencode_test_root: /tmp/agent-opencode/default
+    agent_opencode_fake_bin: "{{ agent_opencode_test_root }}/fake-bin"
+    agent_opencode_config_dir_test: "{{ agent_opencode_test_root }}/home/.config/opencode"
+    agent_opencode_data_dir_test: "{{ agent_opencode_test_root }}/home/.local/share/opencode"
+  tasks:
+    - name: 再次执行 agent_opencode 角色
+      include_role:
+        name: agent_opencode
+      vars:
+        agent_opencode_config_dir: "{{ agent_opencode_config_dir_test }}"
+        agent_opencode_data_dir: "{{ agent_opencode_data_dir_test }}"
+        agent_opencode_temp_root: "{{ agent_opencode_test_root }}/tmp"
+        agent_opencode_confirm_config_update: false
+        agent_opencode_confirm_tui_config_update: false
+        agent_opencode_confirm_sensitive_update: false
+        agent_opencode_config:
+          "$schema": https://opencode.ai/config.json
+          model: ppio/pa-gpt-5.4
+          small_model: ppio/pa-gpt-5.4
+          autoupdate: false
+          permission:
+            edit: ask
+            bash: ask
+          provider:
+            ppio:
+              npm: "@ai-sdk/openai"
+              name: PPIO
+              options:
+                baseURL: https://api.ppio.com/openai/v1
+                apiKey: "{file:/tmp/agent-opencode/default/home/.local/share/opencode/managed-secrets/ppio-api-key}"
+              models:
+                pa-gpt-5.4:
+                  name: PPIO GPT-5.4
+          mcp:
+            fetch:
+              type: local
+              command:
+                - uvx
+                - mcp-server-fetch
+              enabled: true
+            websearch:
+              type: local
+              command:
+                - npx
+                - -y
+                - open-websearch@latest
+              environment:
+                MODE: stdio
+              timeout: 20000
+            deepwiki:
+              type: remote
+              url: https://mcp.deepwiki.com/mcp
+              enabled: true
+              headers:
+                Authorization: "Bearer {env:DEEPWIKI_TOKEN}"
+        agent_opencode_tui_config:
+          theme: system
+        agent_opencode_secret_files:
+          ppio-api-key: test-key
+        agent_opencode_asset_dirs:
+          agents: "{{ playbook_dir }}/files/assets/agents"
+          commands: "{{ playbook_dir }}/files/assets/commands"
+
+    - name: 解析最终 opencode.json
+      command:
+        argv:
+          - python3
+          - -c
+          - import json, pathlib, sys; print(json.dumps(json.loads(pathlib.Path(sys.argv[1]).read_text(encoding='utf-8')), ensure_ascii=False))
+          - "{{ agent_opencode_config_dir_test }}/opencode.json"
+      register: agent_opencode_config_final
+      changed_when: false
+
+    - name: 解析最终 tui.json
+      command:
+        argv:
+          - python3
+          - -c
+          - import json, pathlib, sys; print(json.dumps(json.loads(pathlib.Path(sys.argv[1]).read_text(encoding='utf-8')), ensure_ascii=False))
+          - "{{ agent_opencode_config_dir_test }}/tui.json"
+      register: agent_opencode_tui_final
+      changed_when: false
+
+    - name: 读取 secret file 状态
+      stat:
+        path: "{{ agent_opencode_data_dir_test }}/managed-secrets/ppio-api-key"
+      register: agent_opencode_secret_final
+
+    - name: 读取 assets 状态
+      stat:
+        path: "{{ item }}"
+      loop:
+        - "{{ agent_opencode_config_dir_test }}/agents/reviewer.md"
+        - "{{ agent_opencode_config_dir_test }}/commands/hello.md"
+      register: agent_opencode_assets_final
+
+    - name: 断言 OpenCode 结果
+      assert:
+        that:
+          - not (agent_opencode_result.changed | bool)
+          - (agent_opencode_config_final.stdout | from_json).model == 'ppio/pa-gpt-5.4'
+          - (agent_opencode_config_final.stdout | from_json).provider.ppio.options.baseURL == 'https://api.ppio.com/openai/v1'
+          - (agent_opencode_config_final.stdout | from_json).provider.ppio.options.apiKey == '{file:/tmp/agent-opencode/default/home/.local/share/opencode/managed-secrets/ppio-api-key}'
+          - (agent_opencode_config_final.stdout | from_json).mcp.fetch.command == ['uvx', 'mcp-server-fetch']
+          - (agent_opencode_config_final.stdout | from_json).mcp.websearch.environment.MODE == 'stdio'
+          - (agent_opencode_config_final.stdout | from_json).mcp.websearch.timeout == 20000
+          - (agent_opencode_config_final.stdout | from_json).mcp.deepwiki.type == 'remote'
+          - (agent_opencode_config_final.stdout | from_json).mcp.deepwiki.headers.Authorization == 'Bearer {env:DEEPWIKI_TOKEN}'
+          - (agent_opencode_tui_final.stdout | from_json).theme == 'system'
+          - agent_opencode_secret_final.stat.exists
+          - agent_opencode_secret_final.stat.mode == '0600'
+          - agent_opencode_assets_final.results | map(attribute='stat.exists') | min
+        fail_msg: "agent_opencode 场景验证失败"
+        success_msg: "✓ agent_opencode 场景通过"

--- a/roles/agent_opencode/tasks/main.yml
+++ b/roles/agent_opencode/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+- name: OpenCode 自动化配置入口
+  include_tasks: validate.yml
+
+- name: OpenCode opencode.json 阶段
+  include_tasks: sync_config.yml
+  when: agent_opencode_manage_config | bool
+
+- name: OpenCode tui.json 阶段
+  include_tasks: sync_tui_config.yml
+  when: agent_opencode_should_manage_tui_config | bool
+
+- name: OpenCode 敏感文件阶段
+  include_tasks: sync_sensitive_files.yml
+  when: agent_opencode_should_manage_sensitive_files | bool
+
+- name: OpenCode 资产同步阶段
+  include_tasks: sync_assets.yml
+  when: agent_opencode_should_manage_assets | bool
+
+- name: OpenCode 验证阶段
+  include_tasks: verify.yml
+  when: agent_opencode_run_verify | bool
+
+- name: 汇总 OpenCode 自动化配置结果
+  set_fact:
+    agent_opencode_result:
+      changed: >-
+        {{
+          (agent_opencode_config_result.changed | bool)
+          or (agent_opencode_tui_config_result.changed | bool)
+          or (agent_opencode_sensitive_changed | bool)
+          or (agent_opencode_assets_changed | bool)
+        }}
+      opencode_cli: "{{ agent_opencode_opencode_status }}"
+      config: "{{ agent_opencode_config_result }}"
+      tui_config: "{{ agent_opencode_tui_config_result }}"
+      sensitive_files: "{{ agent_opencode_sensitive_results }}"
+      assets: "{{ agent_opencode_asset_results }}"
+  changed_when: false

--- a/roles/agent_opencode/tasks/sync_asset_dir.yml
+++ b/roles/agent_opencode/tasks/sync_asset_dir.yml
@@ -1,0 +1,26 @@
+---
+- name: 同步 OpenCode {{ agent_opencode_asset_item.key }} 目录
+  include_role:
+    name: managed_tree
+  vars:
+    managed_tree_display_name: "OpenCode {{ agent_opencode_asset_item.key }}"
+    managed_tree_src: "{{ (agent_opencode_asset_item.value | regex_replace('/+$', '')) ~ '/' }}"
+    managed_tree_dest: "{{ agent_opencode_config_dir }}/{{ agent_opencode_asset_item.key }}/"
+    managed_tree_delete: "{{ agent_opencode_asset_delete }}"
+
+- name: 记录 OpenCode {{ agent_opencode_asset_item.key }} 资产同步结果
+  set_fact:
+    agent_opencode_asset_results: >-
+      {{
+        agent_opencode_asset_results
+        + [
+          managed_tree_result
+          | combine({'name': agent_opencode_asset_item.key}, recursive=True)
+        ]
+      }}
+    agent_opencode_assets_changed: >-
+      {{
+        (agent_opencode_assets_changed | bool)
+        or (managed_tree_result.changed | bool)
+      }}
+  changed_when: false

--- a/roles/agent_opencode/tasks/sync_assets.yml
+++ b/roles/agent_opencode/tasks/sync_assets.yml
@@ -1,0 +1,14 @@
+---
+- name: 显示阶段信息
+  debug:
+    msg: |
+      ========================================
+      阶段 5：同步 OpenCode 资产目录
+      ========================================
+
+- name: 同步 OpenCode 资产目录
+  include_tasks: sync_asset_dir.yml
+  loop: "{{ agent_opencode_asset_dirs | dict2items }}"
+  loop_control:
+    loop_var: agent_opencode_asset_item
+    label: "{{ agent_opencode_asset_item.key }}"

--- a/roles/agent_opencode/tasks/sync_config.yml
+++ b/roles/agent_opencode/tasks/sync_config.yml
@@ -1,0 +1,27 @@
+---
+- name: 显示阶段信息
+  debug:
+    msg: |
+      ========================================
+      阶段 2：同步 opencode.json
+      ========================================
+
+- name: 通过 managed_file 管理 opencode.json
+  include_role:
+    name: managed_file
+  vars:
+    managed_file_display_name: opencode.json
+    managed_file_dest: "{{ agent_opencode_config_path }}"
+    managed_file_temp_path: "{{ agent_opencode_temp_root }}/opencode.json.rendered"
+    managed_file_template_src: "{{ agent_opencode_role_path }}/templates/opencode.json.j2"
+    managed_file_mode: "0644"
+    managed_file_compare_kind: json_sorted
+    managed_file_confirm: "{{ agent_opencode_confirm_config_update }}"
+    managed_file_backup: "{{ agent_opencode_backup }}"
+    managed_file_backup_dir: "{{ agent_opencode_config_backup_dir }}"
+    managed_file_backup_prefix: "{{ agent_opencode_config_backup_prefix }}"
+
+- name: 记录 opencode.json 同步结果
+  set_fact:
+    agent_opencode_config_result: "{{ managed_file_result }}"
+  changed_when: false

--- a/roles/agent_opencode/tasks/sync_sensitive_file.yml
+++ b/roles/agent_opencode/tasks/sync_sensitive_file.yml
@@ -1,0 +1,155 @@
+---
+- name: 计算 OpenCode 敏感文件临时路径
+  set_fact:
+    agent_opencode_sensitive_temp_path: >-
+      {{ agent_opencode_temp_root }}/{{ agent_opencode_sensitive_file.name | regex_replace('[^A-Za-z0-9_.-]+', '_') }}.sensitive.rendered
+    agent_opencode_sensitive_backup_path: ""
+  changed_when: false
+
+- name: 确保 OpenCode 敏感文件目标目录存在
+  file:
+    path: "{{ agent_opencode_sensitive_file.path | dirname }}"
+    state: directory
+    mode: "0700"
+
+- name: 写入 OpenCode 敏感文件临时内容
+  copy:
+    dest: "{{ agent_opencode_sensitive_temp_path }}"
+    content: "{{ agent_opencode_sensitive_file.content }}"
+    mode: "{{ agent_opencode_sensitive_file.mode }}"
+  changed_when: false
+
+- name: 检查现有 OpenCode 敏感文件
+  stat:
+    path: "{{ agent_opencode_sensitive_file.path }}"
+    checksum_algorithm: sha256
+  register: agent_opencode_sensitive_existing
+
+- name: 检查新 OpenCode 敏感文件
+  stat:
+    path: "{{ agent_opencode_sensitive_temp_path }}"
+    checksum_algorithm: sha256
+  register: agent_opencode_sensitive_new
+
+- name: 计算 OpenCode 敏感文件内容和权限状态
+  set_fact:
+    agent_opencode_sensitive_file_content_changed: >-
+      {{
+        (not agent_opencode_sensitive_existing.stat.exists)
+        or (
+          (agent_opencode_sensitive_existing.stat.checksum | default(''))
+          != (agent_opencode_sensitive_new.stat.checksum | default(''))
+        )
+      }}
+    agent_opencode_sensitive_file_mode_changed: >-
+      {{
+        agent_opencode_sensitive_existing.stat.exists
+        and (
+          (agent_opencode_sensitive_existing.stat.mode | default(''))
+          != agent_opencode_sensitive_file.mode
+        )
+      }}
+    agent_opencode_sensitive_file_created: "{{ not agent_opencode_sensitive_existing.stat.exists }}"
+  changed_when: false
+
+- name: 汇总 OpenCode 敏感文件是否变更
+  set_fact:
+    agent_opencode_sensitive_file_changed: >-
+      {{
+        (agent_opencode_sensitive_file_content_changed | bool)
+        or (agent_opencode_sensitive_file_mode_changed | bool)
+      }}
+  changed_when: false
+
+- name: 询问是否继续更新 OpenCode 敏感文件
+  pause:
+    prompt: |
+      ========================================
+      检测到 OpenCode 敏感文件变更
+      ========================================
+      文件：{{ agent_opencode_sensitive_file.path }}
+      差异内容不会显示。
+
+      是否继续？(yes/no)
+  when:
+    - agent_opencode_sensitive_file_changed | bool
+    - agent_opencode_confirm_sensitive_update | bool
+  register: agent_opencode_sensitive_user_confirmation
+
+- name: 确认用户选择（OpenCode 敏感文件）
+  fail:
+    msg: "用户取消了 OpenCode 敏感文件更新：{{ agent_opencode_sensitive_file.path }}"
+  when:
+    - agent_opencode_sensitive_file_changed | bool
+    - agent_opencode_confirm_sensitive_update | bool
+    - agent_opencode_sensitive_user_confirmation.user_input | default('') | lower not in ['yes', 'y']
+
+- name: 确保 OpenCode 敏感文件备份目录存在
+  file:
+    path: "{{ agent_opencode_sensitive_backup_dir }}"
+    state: directory
+    mode: "0700"
+  when:
+    - agent_opencode_backup | bool
+    - agent_opencode_sensitive_existing.stat.exists
+    - agent_opencode_sensitive_file_content_changed | bool
+
+- name: 生成 OpenCode 敏感文件备份路径
+  set_fact:
+    agent_opencode_sensitive_backup_path: >-
+      {{ agent_opencode_sensitive_backup_dir }}/{{ agent_opencode_sensitive_file.backup_prefix }}.{{ now(fmt='%Y%m%d_%H%M%S') }}
+  when:
+    - agent_opencode_backup | bool
+    - agent_opencode_sensitive_existing.stat.exists
+    - agent_opencode_sensitive_file_content_changed | bool
+  changed_when: false
+
+- name: 备份现有 OpenCode 敏感文件
+  copy:
+    src: "{{ agent_opencode_sensitive_file.path }}"
+    dest: "{{ agent_opencode_sensitive_backup_path }}"
+    remote_src: true
+    mode: "{{ agent_opencode_sensitive_file.mode }}"
+  when:
+    - agent_opencode_backup | bool
+    - agent_opencode_sensitive_existing.stat.exists
+    - agent_opencode_sensitive_file_content_changed | bool
+
+- name: 更新 OpenCode 敏感文件
+  copy:
+    src: "{{ agent_opencode_sensitive_temp_path }}"
+    dest: "{{ agent_opencode_sensitive_file.path }}"
+    remote_src: true
+    mode: "{{ agent_opencode_sensitive_file.mode }}"
+  when: agent_opencode_sensitive_file_changed | bool
+
+- name: 记录 OpenCode 敏感文件同步结果
+  set_fact:
+    agent_opencode_sensitive_results: >-
+      {{
+        agent_opencode_sensitive_results
+        + [
+          {
+            'name': agent_opencode_sensitive_file.name,
+            'path': agent_opencode_sensitive_file.path,
+            'changed': agent_opencode_sensitive_file_changed | bool,
+            'content_changed': agent_opencode_sensitive_file_content_changed | bool,
+            'mode_changed': agent_opencode_sensitive_file_mode_changed | bool,
+            'created': agent_opencode_sensitive_file_created | bool,
+            'mode': agent_opencode_sensitive_file.mode,
+            'backup_path': agent_opencode_sensitive_backup_path
+          }
+        ]
+      }}
+    agent_opencode_sensitive_changed: >-
+      {{
+        (agent_opencode_sensitive_changed | bool)
+        or (agent_opencode_sensitive_file_changed | bool)
+      }}
+  changed_when: false
+
+- name: 清理 OpenCode 敏感文件临时文件
+  file:
+    path: "{{ agent_opencode_sensitive_temp_path }}"
+    state: absent
+  changed_when: false

--- a/roles/agent_opencode/tasks/sync_sensitive_files.yml
+++ b/roles/agent_opencode/tasks/sync_sensitive_files.yml
@@ -1,0 +1,15 @@
+---
+- name: 显示阶段信息
+  debug:
+    msg: |
+      ========================================
+      阶段 4：同步 OpenCode 敏感文件
+      ========================================
+
+- name: 同步 OpenCode 敏感文件
+  include_tasks: sync_sensitive_file.yml
+  loop: "{{ agent_opencode_sensitive_files_effective }}"
+  loop_control:
+    loop_var: agent_opencode_sensitive_file
+    label: "{{ agent_opencode_sensitive_file.name }}"
+  no_log: true

--- a/roles/agent_opencode/tasks/sync_tui_config.yml
+++ b/roles/agent_opencode/tasks/sync_tui_config.yml
@@ -1,0 +1,27 @@
+---
+- name: 显示阶段信息
+  debug:
+    msg: |
+      ========================================
+      阶段 3：同步 tui.json
+      ========================================
+
+- name: 通过 managed_file 管理 tui.json
+  include_role:
+    name: managed_file
+  vars:
+    managed_file_display_name: tui.json
+    managed_file_dest: "{{ agent_opencode_tui_config_path }}"
+    managed_file_temp_path: "{{ agent_opencode_temp_root }}/tui.json.rendered"
+    managed_file_template_src: "{{ agent_opencode_role_path }}/templates/tui.json.j2"
+    managed_file_mode: "0644"
+    managed_file_compare_kind: json_sorted
+    managed_file_confirm: "{{ agent_opencode_confirm_tui_config_update }}"
+    managed_file_backup: "{{ agent_opencode_backup }}"
+    managed_file_backup_dir: "{{ agent_opencode_tui_config_backup_dir }}"
+    managed_file_backup_prefix: "{{ agent_opencode_tui_config_backup_prefix }}"
+
+- name: 记录 tui.json 同步结果
+  set_fact:
+    agent_opencode_tui_config_result: "{{ managed_file_result }}"
+  changed_when: false

--- a/roles/agent_opencode/tasks/validate.yml
+++ b/roles/agent_opencode/tasks/validate.yml
@@ -1,0 +1,221 @@
+---
+- name: 显示阶段信息
+  debug:
+    msg: |
+      ========================================
+      阶段 1：校验 OpenCode 配置输入
+      ========================================
+
+- name: 校验 OpenCode 角色输入
+  assert:
+    that:
+      - agent_opencode_config_dir | length > 0
+      - agent_opencode_data_dir | length > 0
+      - agent_opencode_config_path | length > 0
+      - agent_opencode_tui_config_path | length > 0
+      - agent_opencode_auth_path | length > 0
+      - agent_opencode_mcp_auth_path | length > 0
+      - agent_opencode_secret_dir | length > 0
+      - agent_opencode_temp_root | length > 0
+      - agent_opencode_config is mapping
+      - agent_opencode_tui_config is mapping
+      - agent_opencode_secret_files is mapping
+      - agent_opencode_auth is mapping
+      - agent_opencode_mcp_auth is mapping
+      - agent_opencode_asset_dirs is mapping
+    fail_msg: >-
+      agent_opencode 角色参数无效：请确保 config_dir / data_dir / path / temp_root 非空，
+      且 config / tui_config / secret_files / auth / mcp_auth / asset_dirs 为对象结构。
+
+- name: 校验 OpenCode 资产目录声明
+  assert:
+    that:
+      - item.key in agent_opencode_allowed_asset_dirs
+      - item.value is string
+      - item.value | length > 0
+    fail_msg: >-
+      OpenCode 资产目录 {{ item.key }} 无效：key 必须是 agents/commands/modes/plugins/skills/tools/themes，
+      value 必须是非空源目录路径。
+  loop: "{{ agent_opencode_asset_dirs | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+
+- name: 归一化 OpenCode 配置对象
+  set_fact:
+    agent_opencode_config_normalized: >-
+      {{
+        {
+          '$schema': 'https://opencode.ai/config.json',
+          'provider': {},
+          'mcp': {}
+        } | combine(agent_opencode_config, recursive=True)
+      }}
+    agent_opencode_tui_config_normalized: "{{ agent_opencode_tui_config | default({}) }}"
+  changed_when: false
+
+- name: 归一化 OpenCode 辅助变量
+  set_fact:
+    agent_opencode_should_manage_tui_config: >-
+      {{
+        (agent_opencode_manage_tui_config | bool)
+        and (agent_opencode_tui_config_normalized | length > 0)
+      }}
+    agent_opencode_should_manage_auth: >-
+      {{
+        (agent_opencode_manage_auth | bool)
+        and (agent_opencode_auth | length > 0)
+      }}
+    agent_opencode_should_manage_mcp_auth: >-
+      {{
+        (agent_opencode_manage_mcp_auth | bool)
+        and (agent_opencode_mcp_auth | length > 0)
+      }}
+    agent_opencode_should_manage_assets: >-
+      {{
+        (agent_opencode_manage_assets | bool)
+        and (agent_opencode_asset_dirs | length > 0)
+      }}
+    agent_opencode_config_result:
+      changed: false
+      path: "{{ agent_opencode_config_path }}"
+    agent_opencode_tui_config_result:
+      changed: false
+      path: "{{ agent_opencode_tui_config_path }}"
+    agent_opencode_sensitive_results: []
+    agent_opencode_sensitive_changed: false
+    agent_opencode_asset_results: []
+    agent_opencode_assets_changed: false
+    agent_opencode_opencode_status: {}
+    agent_opencode_role_path: "{{ role_path }}"
+  changed_when: false
+
+- name: 归一化 OpenCode 敏感文件列表
+  no_log: true
+  block:
+    - name: 初始化 OpenCode 敏感文件列表
+      set_fact:
+        agent_opencode_sensitive_files_effective: []
+      changed_when: false
+
+    - name: 加入 OpenCode secret files
+      set_fact:
+        agent_opencode_sensitive_files_effective: >-
+          {{
+            agent_opencode_sensitive_files_effective
+            + [
+              {
+                'name': item.key,
+                'path': (
+                  item.value.path
+                  if (item.value is mapping and item.value.path is defined)
+                  else (agent_opencode_secret_dir ~ '/' ~ item.key)
+                ),
+                'content': (
+                  item.value.content
+                  if (item.value is mapping and item.value.content is defined)
+                  else (item.value if item.value is not mapping else '')
+                ),
+                'mode': (
+                  item.value.mode
+                  if (item.value is mapping and item.value.mode is defined)
+                  else '0600'
+                ),
+                'backup_prefix': 'secret-' ~ item.key
+              }
+            ]
+          }}
+      loop: "{{ agent_opencode_secret_files | dict2items }}"
+      loop_control:
+        label: "{{ item.key }}"
+      when: agent_opencode_manage_secret_files | bool
+      changed_when: false
+
+    - name: 加入 OpenCode auth.json
+      set_fact:
+        agent_opencode_sensitive_files_effective: >-
+          {{
+            agent_opencode_sensitive_files_effective
+            + [
+              {
+                'name': 'auth.json',
+                'path': agent_opencode_auth_path,
+                'content': agent_opencode_auth | to_nice_json,
+                'mode': '0600',
+                'backup_prefix': 'auth.json'
+              }
+            ]
+          }}
+      when: agent_opencode_should_manage_auth | bool
+      changed_when: false
+
+    - name: 加入 OpenCode mcp-auth.json
+      set_fact:
+        agent_opencode_sensitive_files_effective: >-
+          {{
+            agent_opencode_sensitive_files_effective
+            + [
+              {
+                'name': 'mcp-auth.json',
+                'path': agent_opencode_mcp_auth_path,
+                'content': agent_opencode_mcp_auth | to_nice_json,
+                'mode': '0600',
+                'backup_prefix': 'mcp-auth.json'
+              }
+            ]
+          }}
+      when: agent_opencode_should_manage_mcp_auth | bool
+      changed_when: false
+
+- name: 计算 OpenCode 是否需要管理敏感文件
+  set_fact:
+    agent_opencode_should_manage_sensitive_files: "{{ agent_opencode_sensitive_files_effective | length > 0 }}"
+  changed_when: false
+
+- name: 确保 OpenCode 配置目录存在
+  file:
+    path: "{{ agent_opencode_config_dir }}"
+    state: directory
+    mode: "0755"
+
+- name: 确保 OpenCode 数据目录存在
+  file:
+    path: "{{ agent_opencode_data_dir }}"
+    state: directory
+    mode: "0755"
+
+- name: 确保 OpenCode 临时目录存在
+  file:
+    path: "{{ agent_opencode_temp_root }}"
+    state: directory
+    mode: "0700"
+
+- name: 检查 OpenCode CLI
+  include_role:
+    name: npm_command_bootstrap
+  vars:
+    npm_command_bootstrap_key: opencode
+    npm_command_bootstrap_display_name: OpenCode CLI
+    npm_command_bootstrap_command: opencode
+    npm_command_bootstrap_version_command: opencode --version
+    npm_command_bootstrap_auto_install_npm: >-
+      {{ agent_opencode_opencode_auto_install_npm if (agent_opencode_opencode_auto_install_npm | length > 0) else omit }}
+    npm_command_bootstrap_required: "{{ agent_opencode_require_opencode_cli | bool }}"
+    npm_command_bootstrap_fail_message: "未检测到可用的 OpenCode CLI，无法继续执行 OpenCode 配置。"
+    npm_command_bootstrap_install_fail_message: "OpenCode CLI 自动安装失败，请检查 npm 环境或手动安装。"
+  when: agent_opencode_require_opencode_cli | bool
+
+- name: 暴露 OpenCode CLI 状态
+  set_fact:
+    agent_opencode_opencode_status: "{{ npm_command_bootstrap_results.opencode | default({}) }}"
+  changed_when: false
+  when:
+    - agent_opencode_require_opencode_cli | bool
+    - npm_command_bootstrap_results is defined
+
+- name: 显示 OpenCode CLI 状态汇总
+  debug:
+    msg: |
+      ----------------------------------------
+      OpenCode CLI：{{ agent_opencode_opencode_status.version | default('未检查') }}
+      ----------------------------------------
+  when: agent_opencode_require_opencode_cli | bool

--- a/roles/agent_opencode/tasks/verify.yml
+++ b/roles/agent_opencode/tasks/verify.yml
@@ -1,0 +1,166 @@
+---
+- name: 显示阶段信息
+  debug:
+    msg: |
+      ========================================
+      阶段 6：验证 OpenCode 配置结果
+      ========================================
+
+- name: 检查 opencode.json 是否存在
+  stat:
+    path: "{{ agent_opencode_config_path }}"
+  register: agent_opencode_config_stat
+  when: agent_opencode_manage_config | bool
+
+- name: 验证 opencode.json 存在
+  assert:
+    that:
+      - agent_opencode_config_stat.stat.exists
+      - agent_opencode_config_stat.stat.isreg
+    fail_msg: "opencode.json 不存在"
+    success_msg: "✓ opencode.json 已生成"
+  when: agent_opencode_manage_config | bool
+
+- name: 解析 opencode.json
+  command:
+    argv:
+      - "{{ ansible_python_interpreter | default('/usr/bin/python3') }}"
+      - -c
+      - import json, pathlib, sys; print(json.dumps(json.loads(pathlib.Path(sys.argv[1]).read_text(encoding='utf-8')), ensure_ascii=False))
+      - "{{ agent_opencode_config_path }}"
+  register: agent_opencode_config_parse
+  changed_when: false
+  when: agent_opencode_manage_config | bool
+
+- name: 保存解析后的 opencode.json
+  set_fact:
+    agent_opencode_config_data: "{{ agent_opencode_config_parse.stdout | from_json }}"
+  changed_when: false
+  when: agent_opencode_manage_config | bool
+
+- name: 验证 opencode.json 已正确写入
+  assert:
+    that:
+      - agent_opencode_config_data == agent_opencode_config_normalized
+    fail_msg: "opencode.json 内容与期望配置不一致"
+    success_msg: "✓ opencode.json 内容正确"
+  when: agent_opencode_manage_config | bool
+
+- name: 检查 tui.json 是否存在
+  stat:
+    path: "{{ agent_opencode_tui_config_path }}"
+  register: agent_opencode_tui_config_stat
+  when: agent_opencode_should_manage_tui_config | bool
+
+- name: 验证 tui.json 存在
+  assert:
+    that:
+      - agent_opencode_tui_config_stat.stat.exists
+      - agent_opencode_tui_config_stat.stat.isreg
+    fail_msg: "tui.json 不存在"
+    success_msg: "✓ tui.json 已生成"
+  when: agent_opencode_should_manage_tui_config | bool
+
+- name: 解析 tui.json
+  command:
+    argv:
+      - "{{ ansible_python_interpreter | default('/usr/bin/python3') }}"
+      - -c
+      - import json, pathlib, sys; print(json.dumps(json.loads(pathlib.Path(sys.argv[1]).read_text(encoding='utf-8')), ensure_ascii=False))
+      - "{{ agent_opencode_tui_config_path }}"
+  register: agent_opencode_tui_config_parse
+  changed_when: false
+  when: agent_opencode_should_manage_tui_config | bool
+
+- name: 验证 tui.json 已正确写入
+  assert:
+    that:
+      - (agent_opencode_tui_config_parse.stdout | from_json) == agent_opencode_tui_config_normalized
+    fail_msg: "tui.json 内容与期望配置不一致"
+    success_msg: "✓ tui.json 内容正确"
+  when: agent_opencode_should_manage_tui_config | bool
+
+- name: 验证 OpenCode 敏感文件已同步
+  stat:
+    path: "{{ item.path }}"
+  register: agent_opencode_sensitive_verify_stats
+  loop: "{{ agent_opencode_sensitive_results }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when: agent_opencode_should_manage_sensitive_files | bool
+
+- name: 断言 OpenCode 敏感文件状态
+  assert:
+    that:
+      - item.stat.exists
+      - item.stat.isreg
+      - item.stat.mode == item.item.mode
+    fail_msg: "OpenCode 敏感文件未正确同步或权限不正确"
+    success_msg: "✓ OpenCode 敏感文件权限正确"
+  loop: "{{ agent_opencode_sensitive_verify_stats.results }}"
+  loop_control:
+    label: "{{ item.item.name }}"
+  when: agent_opencode_should_manage_sensitive_files | bool
+
+- name: 检查 OpenCode 资产目录
+  stat:
+    path: "{{ agent_opencode_config_dir }}/{{ item.key }}"
+  register: agent_opencode_asset_verify_stats
+  loop: "{{ agent_opencode_asset_dirs | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+  when: agent_opencode_should_manage_assets | bool
+
+- name: 断言 OpenCode 资产目录状态
+  assert:
+    that:
+      - item.stat.exists
+      - item.stat.isdir
+    fail_msg: "OpenCode 资产目录未正确同步"
+    success_msg: "✓ OpenCode 资产目录已同步"
+  loop: "{{ agent_opencode_asset_verify_stats.results }}"
+  loop_control:
+    label: "{{ item.item.key }}"
+  when: agent_opencode_should_manage_assets | bool
+
+- name: 执行 OpenCode opencode.json Schema 校验
+  when:
+    - agent_opencode_manage_config | bool
+    - agent_opencode_verify_schema | bool
+  block:
+    - name: 在控制端创建 OpenCode opencode.json Schema 校验临时文件
+      tempfile:
+        state: file
+        suffix: .json
+      register: agent_opencode_config_schema_temp
+      delegate_to: localhost
+      become: false
+
+    - name: 写入 OpenCode opencode.json 到控制端临时文件
+      copy:
+        dest: "{{ agent_opencode_config_schema_temp.path }}"
+        content: "{{ agent_opencode_config_parse.stdout }}"
+        mode: "0600"
+      delegate_to: localhost
+      become: false
+
+    - name: 校验 OpenCode opencode.json Schema
+      command:
+        argv:
+          - check-jsonschema
+          - --schemafile
+          - "{{ agent_opencode_config_schemafile }}"
+          - "{{ agent_opencode_config_schema_temp.path }}"
+      changed_when: false
+      delegate_to: localhost
+      become: false
+  always:
+    - name: 清理 OpenCode opencode.json Schema 校验临时文件
+      file:
+        path: "{{ agent_opencode_config_schema_temp.path }}"
+        state: absent
+      delegate_to: localhost
+      become: false
+      when:
+        - agent_opencode_config_schema_temp is defined
+        - agent_opencode_config_schema_temp.path is defined

--- a/roles/agent_opencode/templates/opencode.json.j2
+++ b/roles/agent_opencode/templates/opencode.json.j2
@@ -1,0 +1,1 @@
+{{ agent_opencode_config_normalized | to_nice_json }}

--- a/roles/agent_opencode/templates/tui.json.j2
+++ b/roles/agent_opencode/templates/tui.json.j2
@@ -1,0 +1,1 @@
+{{ agent_opencode_tui_config_normalized | to_nice_json }}


### PR DESCRIPTION
## 摘要
- 新增 `agent_opencode` role，支持 OpenCode CLI 检查、`opencode.json`、可选 `tui.json`、敏感文件与资产目录同步
- 新增 `playbooks/setup_opencode.yml`，完成 inventory 变量归一化和共享 MCP 到 OpenCode MCP 结构转换
- 新增默认 OpenCode inventory、Molecule 场景，并更新 README、AGENTS、共享 MCP 注释和 CI matrix

## 验证
- `cd roles/agent_opencode && uv run molecule test`
- 全入口 playbook `uv run ansible-playbook --syntax-check ...`
- `git diff --cached --check`
- staged diff 简单敏感字符串扫描无命中