### PR TITLE
fix(ci): repair default inventory validation

### DIFF
--- a/inventory/default/group_vars/all/agent_skills/items.yml
+++ b/inventory/default/group_vars/all/agent_skills/items.yml
@@ -52,9 +52,9 @@ agent_skills_items:
     agents: "{{ agent_skills_default_agents }}"
     scope: global
 
-  - name: 安装 github/awesome-copilot 官方相关 Skills
+  - name: 安装 trailofbits/skills 的 gh-cli Skill
     state: present
-    source: github/awesome-copilot
+    source: trailofbits/skills
     skills:
       - gh-cli # GitHub CLI 相关技能，提供与 GitHub 仓库、Issue、PR 等交互的能力
     agents: "{{ agent_skills_default_agents }}"

--- a/inventory/default/group_vars/all/claude_code/settings.yml
+++ b/inventory/default/group_vars/all/claude_code/settings.yml
@@ -28,7 +28,7 @@ claude_code_settings:
     # MCP 超时时间（毫秒）
     MCP_TIMEOUT: "30000"
     # 禁用 Claude Code 注入的时间戳 header，防止KV缓存失效
-    CLAUDE_CODE_ATTRIBUTION_HEADER: 0
+    CLAUDE_CODE_ATTRIBUTION_HEADER: "0"
 
   # ===== 输出风格与语言 =====
   outputStyle: "engineer-professional.md"


### PR DESCRIPTION
## Summary
- quote `CLAUDE_CODE_ATTRIBUTION_HEADER` so generated Claude settings pass the current schema
- switch the default `gh-cli` skill source from `github/awesome-copilot` to `trailofbits/skills`, because `github/awesome-copilot` no longer exposes that skill in the current repository scan

## CI failure root cause
- `Setup claude_code` failed schema validation: `$.env.CLAUDE_CODE_ATTRIBUTION_HEADER: 0 is not of type string`
- the remaining matrix jobs failed in `setup_agent_skills.yml`: `skills add github/awesome-copilot ... --skill gh-cli` returned `No matching skills found for: gh-cli`

## Verification
- reproduced the Claude schema failure locally with an isolated `/tmp` home before the fix
- reproduced the `github/awesome-copilot --skill gh-cli` failure before the fix
- `uv run ansible-playbook -i inventory/default/inventory.yml playbooks/setup_claude_code.yml ... claude_code_verify_schema=true` using isolated `/tmp` paths
- `HOME=/tmp/agent-config-skills-green uv run ansible-playbook -i inventory/default/inventory.yml playbooks/setup_agent_skills.yml`
- all CI syntax checks: `uv run ansible-playbook --syntax-check playbooks/setup_{claude_code,codex,gemini_cli,copilot_cli,cursor,opencode,opencommit,agent_skills}.yml`