### PR TITLE
feat: add MCP dependency preheat playbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,12 +24,14 @@ uv run ansible-playbook playbooks/setup_cursor.yml
 uv run ansible-playbook playbooks/setup_opencode.yml
 uv run ansible-playbook playbooks/setup_opencommit.yml
 uv run ansible-playbook playbooks/setup_agent_skills.yml
+uv run ansible-playbook playbooks/preheat_agent_mcps.yml
 
 # 显式指定 profile 运行
 scripts/run-playbook.sh <profile> playbooks/setup_codex.yml
 scripts/run-playbook.sh <profile> playbooks/setup_cursor.yml -e "target_hosts=all"
 scripts/run-playbook.sh <profile> playbooks/setup_opencode.yml
 scripts/run-playbook.sh <profile> playbooks/setup_opencommit.yml
+scripts/run-playbook.sh <profile> playbooks/preheat_agent_mcps.yml
 
 # 面向 inventory 中全部主机执行
 uv run ansible-playbook playbooks/setup_claude_code.yml -e "target_hosts=all"
@@ -40,6 +42,7 @@ uv run ansible-playbook playbooks/setup_cursor.yml -e "target_hosts=all"
 uv run ansible-playbook playbooks/setup_opencode.yml -e "target_hosts=all"
 uv run ansible-playbook playbooks/setup_opencommit.yml -e "target_hosts=all"
 uv run ansible-playbook playbooks/setup_agent_skills.yml -e "target_hosts=all"
+uv run ansible-playbook playbooks/preheat_agent_mcps.yml -e "target_hosts=all"
 
 # Molecule 测试（需进入对应 role 目录）
 cd roles/<role-name>

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 | `playbooks/setup_opencode.yml`     | 部署 OpenCode 的 `opencode.json`、可选 `tui.json`、敏感文件与资产目录 |
 | `playbooks/setup_opencommit.yml`   | 部署 OpenCommit CLI 的 `~/.opencommit`                        |
 | `playbooks/setup_agent_skills.yml` | 通过 `skills` CLI 声明式安装或卸载 skills                     |
+| `playbooks/preheat_agent_mcps.yml` | 批量预热共享 MCP 的 `npx` / `uvx` 启动依赖缓存                |
 
 ## 快速开始
 
@@ -95,6 +96,7 @@ uv run ansible-playbook playbooks/setup_cursor.yml
 uv run ansible-playbook playbooks/setup_opencode.yml
 uv run ansible-playbook playbooks/setup_opencommit.yml
 uv run ansible-playbook playbooks/setup_agent_skills.yml
+uv run ansible-playbook playbooks/preheat_agent_mcps.yml
 ```
 
 如果要显式指定 profile，使用仓库脚本：
@@ -102,6 +104,7 @@ uv run ansible-playbook playbooks/setup_agent_skills.yml
 ```bash
 scripts/run-playbook.sh personal playbooks/setup_codex.yml
 scripts/run-playbook.sh personal playbooks/setup_cursor.yml -e "target_hosts=all"
+scripts/run-playbook.sh personal playbooks/preheat_agent_mcps.yml
 ```
 
 这个脚本的两个必填参数分别是：

--- a/playbooks/preheat_agent_mcps.yml
+++ b/playbooks/preheat_agent_mcps.yml
@@ -1,0 +1,116 @@
+---
+# playbooks/preheat_agent_mcps.yml
+# 共享 MCP 启动依赖批量预热。
+#
+# 功能：
+# 0. 递归加载 inventory/<profile>/group_vars/all 下的所有 yml/yaml 变量片段
+# 1. 读取 agent_mcps 中声明的 stdio MCP 启动命令
+# 2. 在目标机上短暂启动每个命令，让 npx / uvx 下载并缓存固定版本依赖
+#
+# 使用方法：
+#   uv run ansible-playbook -i inventory/default/inventory.yml playbooks/preheat_agent_mcps.yml
+#   scripts/run-playbook.sh <profile> playbooks/preheat_agent_mcps.yml
+#   scripts/run-playbook.sh <profile> playbooks/preheat_agent_mcps.yml -e "target_hosts=all"
+#
+# 可选变量：
+#   -e "mcp_preheat_timeout_sec=120"
+#   -e "mcp_preheat_no_log=false"
+#
+# 注意：
+#   - 预热会执行 MCP 的启动命令，但不会调用任何 MCP 工具。
+#   - 启动后仍在等待 stdio 的服务会在超时后被终止，退出码 124 视为预热成功。
+
+- name: 共享 MCP 启动依赖预热
+  hosts: "{{ target_hosts | default('localhost') }}"
+  gather_facts: false
+  vars:
+    mcp_preheat_runner: |
+      import subprocess
+      import sys
+
+      timeout = int(sys.argv[1])
+      cmd = sys.argv[2:]
+      print("preheat command: " + " ".join(cmd))
+
+      try:
+          result = subprocess.run(
+              cmd,
+              stdin=subprocess.DEVNULL,
+              text=True,
+              timeout=timeout,
+          )
+          raise SystemExit(result.returncode)
+      except subprocess.TimeoutExpired:
+          print("preheat timeout reached; treating running MCP server as warmed")
+          raise SystemExit(124)
+
+  pre_tasks:
+    - name: 递归加载 group_vars/all 变量文件
+      include_vars:
+        dir: "{{ inventory_dir }}/group_vars/all"
+        extensions:
+          - yml
+          - yaml
+        ignore_unknown_extensions: true
+      tags:
+        - always
+
+    - name: 校验 MCP 预热输入
+      assert:
+        that:
+          - (agent_mcps | default({})) is mapping
+          - (mcp_preheat_timeout_sec | default(120) | int) > 0
+        fail_msg: >-
+          MCP 预热输入无效：请检查 group_vars/all/agent_mcps/servers.yml
+          中的 agent_mcps 结构，以及 mcp_preheat_timeout_sec。
+      tags:
+        - always
+
+    - name: 校验 MCP 启动命令
+      assert:
+        that:
+          - item.value.command is string
+          - item.value.command | length > 0
+          - (item.value.args | default([])) is sequence
+          - (item.value.args | default([])) is not string
+          - (item.value.env | default({})) is mapping
+        fail_msg: >-
+          MCP {{ item.key }} 预热输入无效：每个条目必须提供 command 字符串，
+          args 必须是列表，env 必须是字典。
+      loop: "{{ agent_mcps | default({}) | dict2items }}"
+      loop_control:
+        label: "{{ item.key }}"
+      no_log: "{{ mcp_preheat_no_log | default(true) | bool }}"
+      tags:
+        - always
+
+  tasks:
+    - name: 预热 MCP 启动依赖
+      command:
+        argv: >-
+          {{
+            [
+              ansible_python_interpreter | default('/usr/bin/python3'),
+              '-c',
+              mcp_preheat_runner,
+              mcp_preheat_timeout_sec | default(120) | string,
+              item.value.command
+            ]
+            + (item.value.args | default([]))
+          }}
+      environment: >-
+        {{
+          (item.value.env | default({}))
+          | dict2items
+          | rejectattr('value', 'equalto', '')
+          | items2dict
+        }}
+      register: mcp_preheat_result
+      changed_when: false
+      failed_when: mcp_preheat_result.rc not in [0, 124]
+      loop: "{{ agent_mcps | default({}) | dict2items }}"
+      loop_control:
+        label: "{{ item.key }}"
+      no_log: "{{ mcp_preheat_no_log | default(true) | bool }}"
+      tags:
+        - always


### PR DESCRIPTION
## Summary
- Add a playbook that preheats shared MCP stdio command dependencies from agent_mcps.
- Treat long-running MCP server startup timeouts as a successful cache warm-up.
- Document the new playbook in README and AGENTS command lists.

## Test Plan
- uv run ansible-playbook -i inventory/default/inventory.yml playbooks/preheat_agent_mcps.yml --syntax-check
- uv run ansible-playbook -i inventory/default/inventory.yml playbooks/preheat_agent_mcps.yml -e "mcp_preheat_timeout_sec=1"